### PR TITLE
Refactor authorities utils by removing unused category options

### DIFF
--- a/src/pages/portfolio/authorities/utils.ts
+++ b/src/pages/portfolio/authorities/utils.ts
@@ -31,12 +31,4 @@ export const categories = [
 		label: 'Registrar',
 		value: 'registrar',
 	},
-	{
-		label: 'Undergraduate',
-		value: 'undergraduate',
-	},
-	{
-		label: 'Certificate',
-		value: 'certificate',
-	},
 ];


### PR DESCRIPTION
Remove unused category options from the authorities utility to streamline the codebase.