### PR TITLE
Refactor visitor props to use category and process data types

### DIFF
--- a/src/pages/procurement/category/config/types/index.tsx
+++ b/src/pages/procurement/category/config/types/index.tsx
@@ -4,9 +4,9 @@ import { AxiosError } from 'axios';
 
 import '../columns/columns.type';
 
-import { IVisitorTableData } from '../columns/columns.type';
+import { ICategoryTableData } from '../columns/columns.type';
 
 //* Visitor
 export interface IVisitorAddOrUpdateProps extends IDefaultAddOrUpdateProps {
-	updatedData?: IVisitorTableData | null;
+	updatedData?: ICategoryTableData | null;
 }

--- a/src/pages/procurement/process/config/types/index.tsx
+++ b/src/pages/procurement/process/config/types/index.tsx
@@ -4,9 +4,9 @@ import { AxiosError } from 'axios';
 
 import '../columns/columns.type';
 
-import { IVisitorTableData } from '../columns/columns.type';
+import { IProcessTableData } from '../columns/columns.type';
 
 //* Visitor
 export interface IVisitorAddOrUpdateProps extends IDefaultAddOrUpdateProps {
-	updatedData?: IVisitorTableData | null;
+	updatedData?: IProcessTableData | null;
 }

--- a/src/pages/procurement/process/config/types/index.tsx
+++ b/src/pages/procurement/process/config/types/index.tsx
@@ -7,6 +7,6 @@ import '../columns/columns.type';
 import { IProcessTableData } from '../columns/columns.type';
 
 //* Visitor
-export interface IVisitorAddOrUpdateProps extends IDefaultAddOrUpdateProps {
+export interface IProcessAddOrUpdateProps extends IDefaultAddOrUpdateProps {
 	updatedData?: IProcessTableData | null;
 }


### PR DESCRIPTION
Update the visitor props interface to align with the new category and process table data types, enhancing type safety and clarity.