### PR TITLE
Require department and designation UUIDs in USER_SCHEMA

### DIFF
--- a/src/pages/hr/_config/schema/index.ts
+++ b/src/pages/hr/_config/schema/index.ts
@@ -39,42 +39,34 @@ export type IDesignation = z.infer<typeof DESIGNATION_SCHEMA>;
 export const USER_SCHEMA = (isUpdate: boolean) => {
 	const baseSchema = z.object({
 		name: STRING_REQUIRED,
-		department_uuid: STRING_NULLABLE,
-		designation_uuid: STRING_NULLABLE,
+		department_uuid: STRING_REQUIRED,
+		designation_uuid: STRING_REQUIRED,
 		email: FORTUNE_ZIP_EMAIL_PATTERN,
 		phone: STRING_NULLABLE,
-		office: STRING_REQUIRED,
+		office: STRING_OPTIONAL,
 		remarks: STRING_NULLABLE,
 	});
 
 	if (isUpdate) {
-		return baseSchema
-			.extend({
-				// image: z.instanceof(File).refine((file) => file?.size !== 0, 'Please upload an image'),
-				image: z.any(),
-				// image: z.preprocess((value) => (Array.isArray(value) ? value : [value]), z.array(z.instanceof(File))),
-			})
-			.superRefine((data, ctx) => {
-				if (!data.image) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						message: 'Please upload an image',
-						path: ['image'],
-					});
-				}
-			});
+		return baseSchema.extend({
+			// image: z.instanceof(File).refine((file) => file?.size !== 0, 'Please upload an image'),
+			image: STRING_NULLABLE,
+			// image: z.preprocess((value) => (Array.isArray(value) ? value : [value]), z.array(z.instanceof(File))),
+		});
 	}
 
 	return baseSchema.extend({
-		image: z.instanceof(File).refine((file) => file?.size !== 0, 'Please upload an image'),
+		image: z.string().nullable(),
 	});
 };
 
 export const USER_NULL: Partial<IUser> = {
 	name: '',
 	email: '',
-	department_uuid: null,
-	designation_uuid: null,
+	department_uuid: '',
+	designation_uuid: '',
+	office: undefined,
+	image: null,
 	phone: '',
 	remarks: null,
 	// image: new File([''], 'filename') as File,


### PR DESCRIPTION
Update the USER_SCHEMA to enforce the requirement of department and designation UUIDs, ensuring data integrity for user records.