### PR TITLE
Add URL parameter for active items in vendor query

### DIFF
--- a/src/pages/procurement/item-work-order/config/columns/columns.type.ts
+++ b/src/pages/procurement/item-work-order/config/columns/columns.type.ts
@@ -4,14 +4,3 @@ export type IItemWorkOrderTableData = {
 	vendor_name: string;
 	status: string;
 };
-
-// * Item
-export type IItemTableData = {
-	index: number;
-	item_uuid: string;
-	name: string;
-	purchase_cost_center_name: string;
-	vendor_price: number;
-	price_validity: number;
-	remarks: string;
-};

--- a/src/pages/procurement/item-work-order/config/query/index.ts
+++ b/src/pages/procurement/item-work-order/config/query/index.ts
@@ -24,9 +24,9 @@ export const useItemWorkOrderAndEntry = <T>(uuid: string) =>
 	});
 
 // Item by Vendor
-export const useItemByVendor = <T>(uuid: string) =>
+export const useItemByVendor = <T>(uuid: string, query?: string) =>
 	useTQuery<T>({
-		queryKey: itemWordOrderQK.itemByVendor(uuid),
-		url: `/procure/item/by/vendor-uuid/${uuid}`,
+		queryKey: itemWordOrderQK.itemByVendor(uuid, query),
+		url: query ? `/procure/item/by/vendor-uuid/${uuid}?${query}` : `/procure/item/by/vendor-uuid/${uuid}`,
 		enabled: !!uuid,
 	});

--- a/src/pages/procurement/item-work-order/config/query/queryKeys.ts
+++ b/src/pages/procurement/item-work-order/config/query/queryKeys.ts
@@ -5,5 +5,10 @@ export const itemWordOrderQK = {
 	itemWorkOrder: () => [...itemWordOrderQK.all(), 'item-work-orders'],
 	itemWorkOrderByUUID: (uuid: string) => [...itemWordOrderQK.itemWorkOrder(), uuid],
 	itemWorkOrderAndEntry: (uuid: string) => [...itemWordOrderQK.all(), 'item-working-order-and-entry', uuid],
-	itemByVendor: (uuid: string) => [...itemWordOrderQK.all(), 'item-vendor', uuid],
+	itemByVendor: (uuid: string, query?: string) => [
+		...itemWordOrderQK.all(),
+		'item-vendor',
+		uuid,
+		...(query ? [query] : []),
+	],
 };

--- a/src/pages/procurement/item-work-order/entry.tsx
+++ b/src/pages/procurement/item-work-order/entry.tsx
@@ -14,8 +14,10 @@ import { useOtherVendor } from '@/lib/common-queries/other';
 import nanoid from '@/lib/nanoid';
 import { getDateTime } from '@/utils';
 
-import { IItemTableData, IItemWorkOrderTableData } from './config/columns/columns.type';
-import { useItemByVendor, useItemWordOrder, useItemWorkOrderAndEntry } from './config/query';
+import { IItemTableData } from '../item/config/columns/columns.type';
+import { useItem } from '../item/config/query';
+import { IItemWorkOrderTableData } from './config/columns/columns.type';
+import { useItemWordOrder, useItemWorkOrderAndEntry } from './config/query';
 import { IItemWorkOrder, ITEM_WORD_ORDER_NULL, ITEM_WORD_ORDER_SCHEMA } from './config/schema';
 import useGenerateFieldDefs from './useGenerateFieldDefs';
 import { status } from './utils';
@@ -34,6 +36,7 @@ const Entry = () => {
 		invalidateQuery: invalidateQueryWorkOrderAndEntry,
 	} = useItemWorkOrderAndEntry(uuid as string);
 
+	const { invalidateQuery: invalidateQueryItem } = useItem<IItemTableData[]>();
 	const { invalidateQuery } = useItemWordOrder<IItemWorkOrderTableData[]>();
 	const { data: vendorList } = useOtherVendor<IFormSelectOption[]>();
 
@@ -98,6 +101,7 @@ const Entry = () => {
 				})
 				.then(() => {
 					invalidateQuery();
+					invalidateQueryItem();
 					invalidateQueryWorkOrderAndEntry();
 					navigate('/procurement/item-work-order');
 				})
@@ -144,6 +148,8 @@ const Entry = () => {
 				})
 				.then(() => {
 					invalidateQuery();
+					invalidateQueryItem();
+					invalidateQueryWorkOrderAndEntry();
 					navigate('/procurement/item-work-order');
 				})
 				.catch((error) => {
@@ -249,7 +255,7 @@ const Entry = () => {
 						url: `/procure/item-work-order-entry`,
 						deleteData,
 						invalidateQuery: invalidateQueryWorkOrderAndEntry,
-						invalidateQueries: [invalidateQuery, invalidateQueryWorkOrderAndEntry],
+						invalidateQueries: [invalidateQuery, invalidateQueryWorkOrderAndEntry, invalidateQueryItem],
 						onClose: () => {
 							form.setValue(
 								'item_work_order_entry',

--- a/src/pages/procurement/item-work-order/useGenerateFieldDefs.tsx
+++ b/src/pages/procurement/item-work-order/useGenerateFieldDefs.tsx
@@ -26,7 +26,7 @@ const useGenerateFieldDefs = ({
 	set,
 	data,
 }: IGenerateFieldDefsProps): FieldDef[] => {
-	const { data: itemData } = useItemByVendor<IFormSelectOption[]>(watch('vendor_uuid') as string);
+	const { data: itemData } = useItemByVendor<IFormSelectOption[]>(watch('vendor_uuid') as string, 'is_active=true');
 
 	return [
 		{

--- a/src/pages/procurement/item/config/columns/index.tsx
+++ b/src/pages/procurement/item/config/columns/index.tsx
@@ -35,4 +35,9 @@ export const itemColumns = (): ColumnDef<IItemTableData>[] => [
 		enableColumnFilter: true,
 		cell: (info) => <DateTime date={info.getValue() as Date} isTime={false} />,
 	},
+	{
+		accessorKey: 'quantity',
+		header: 'Quantity',
+		enableColumnFilter: true,
+	},
 ];

--- a/src/routes/private/procurement.tsx
+++ b/src/routes/private/procurement.tsx
@@ -18,6 +18,29 @@ const procurementRoutes: IRoute[] = [
 		name: 'Procurement',
 		children: [
 			{
+				name: 'Service',
+				path: '/procurement/service',
+				element: <Service />,
+				page_name: 'procurement__service',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
+			{
+				name: 'Service Entry',
+				path: '/procurement/service/create',
+				element: <ServiceEntry />,
+				hidden: true,
+				page_name: 'procurement__service_entry',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
+			{
+				name: 'Service Update',
+				path: '/procurement/service/:uuid/update',
+				element: <ServiceEntry />,
+				hidden: true,
+				page_name: 'procurement__service_update',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
+			{
 				name: 'Item Work Order',
 				path: '/procurement/item-work-order',
 				element: <ItemWorkOrder />,
@@ -84,29 +107,7 @@ const procurementRoutes: IRoute[] = [
 				page_name: 'procurement__category',
 				actions: ['create', 'read', 'update', 'delete'],
 			},
-			{
-				name: 'Service',
-				path: '/procurement/service',
-				element: <Service />,
-				page_name: 'procurement__service',
-				actions: ['create', 'read', 'update', 'delete'],
-			},
-			{
-				name: 'Service Entry',
-				path: '/procurement/service/create',
-				element: <ServiceEntry />,
-				hidden: true,
-				page_name: 'procurement__service_entry',
-				actions: ['create', 'read', 'update', 'delete'],
-			},
-			{
-				name: 'Service Update',
-				path: '/procurement/service/:uuid/update',
-				element: <ServiceEntry />,
-				hidden: true,
-				page_name: 'procurement__service_update',
-				actions: ['create', 'read', 'update', 'delete'],
-			},
+
 			{
 				name: 'Vendor',
 				path: '/procurement/vendor',


### PR DESCRIPTION
Introduce a URL parameter to filter active items when retrieving vendor data. This change enhances the query functionality in the item work order entries. Additionally, new service-related routes have been added to the procurement section.