### PR TITLE
Add invalidate query in procurement section

### DIFF
--- a/src/pages/procurement/capital/entry.tsx
+++ b/src/pages/procurement/capital/entry.tsx
@@ -309,8 +309,8 @@ const Entry = () => {
 					name='sub_category_uuid'
 					render={(props) => (
 						<CoreForm.ReactSelect
-							label='Status'
-							placeholder='Select status'
+							label='Sub Category'
+							placeholder='Select sub category'
 							menuPortalTarget={document.body}
 							options={subCategoryList!}
 							{...props}
@@ -412,7 +412,13 @@ const Entry = () => {
 					render={(props) => (
 						<CoreForm.ReactSelect
 							label='Vendor'
-							options={vendorList!}
+							options={
+								vendorList?.filter((item) =>
+									form
+										.getValues('quotations')
+										.some((quotation) => quotation.vendor_uuid === item.value)
+								) || []
+							}
 							isDisabled={
 								!(
 									form.watch('is_work_order') &&

--- a/src/pages/procurement/category/add-or-update.tsx
+++ b/src/pages/procurement/category/add-or-update.tsx
@@ -6,6 +6,7 @@ import { FormField } from '@/components/ui/form';
 import CoreForm from '@core/form';
 import { AddModal } from '@core/modal';
 
+import { useOtherCategory } from '@/lib/common-queries/other';
 import nanoid from '@/lib/nanoid';
 import { getDateTime } from '@/utils';
 
@@ -27,6 +28,7 @@ const AddOrUpdate: React.FC<ICategoryAddOrUpdateProps> = ({
 
 	const { user } = useAuth();
 	const { data } = useCategoryByUUID(updatedData?.uuid as string);
+	const { invalidateQuery: invalidateQueryCategory } = useOtherCategory();
 
 	const form = useRHF(CATEGORY_SCHEMA, CATEGORY_NULL);
 
@@ -56,6 +58,7 @@ const AddOrUpdate: React.FC<ICategoryAddOrUpdateProps> = ({
 				},
 				onClose,
 			});
+			invalidateQueryCategory();
 		} else {
 			// ADD NEW ITEM
 			postData.mutateAsync({
@@ -68,6 +71,7 @@ const AddOrUpdate: React.FC<ICategoryAddOrUpdateProps> = ({
 				},
 				onClose,
 			});
+			invalidateQueryCategory();
 		}
 	}
 

--- a/src/pages/procurement/purchaseCostCenter/add-or-update.tsx
+++ b/src/pages/procurement/purchaseCostCenter/add-or-update.tsx
@@ -7,7 +7,7 @@ import { FormField } from '@/components/ui/form';
 import CoreForm from '@core/form';
 import { AddModal } from '@core/modal';
 
-import { useOtherSubCategory } from '@/lib/common-queries/other';
+import { useOtherPurchaseCostCenter, useOtherSubCategory } from '@/lib/common-queries/other';
 import nanoid from '@/lib/nanoid';
 import { getDateTime } from '@/utils';
 
@@ -30,6 +30,7 @@ const AddOrUpdate: React.FC<IPurchaseCostCenterAddOrUpdateProps> = ({
 	const { user } = useAuth();
 	const { data } = usePurchaseCostCenterByUUID(updatedData?.uuid as string);
 	const { data: subCategory } = useOtherSubCategory<IFormSelectOption[]>();
+	const { invalidateQuery: invalidateQueryPurchaseCostCenter } = useOtherPurchaseCostCenter();
 
 	const form = useRHF(PURCHASE_COST_CENTER_SCHEMA, PURCHASE_COST_CENTER_NULL);
 
@@ -60,6 +61,7 @@ const AddOrUpdate: React.FC<IPurchaseCostCenterAddOrUpdateProps> = ({
 				},
 				onClose,
 			});
+			invalidateQueryPurchaseCostCenter();
 		} else {
 			// ADD NEW ITEM
 			postData.mutateAsync({
@@ -72,6 +74,7 @@ const AddOrUpdate: React.FC<IPurchaseCostCenterAddOrUpdateProps> = ({
 				},
 				onClose,
 			});
+			invalidateQueryPurchaseCostCenter();
 		}
 	}
 

--- a/src/pages/procurement/service/entry.tsx
+++ b/src/pages/procurement/service/entry.tsx
@@ -58,7 +58,6 @@ const Entry = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data, isUpdate]);
 
-	console.log(form.formState.errors);
 	// Submit handler
 	async function onSubmit(values: IService) {
 		if (isUpdate) {

--- a/src/pages/procurement/subcategory/add-or-update.tsx
+++ b/src/pages/procurement/subcategory/add-or-update.tsx
@@ -7,7 +7,7 @@ import { FormField } from '@/components/ui/form';
 import CoreForm from '@core/form';
 import { AddModal } from '@core/modal';
 
-import { useOtherCategory } from '@/lib/common-queries/other';
+import { useOtherCategory, useOtherSubCategory } from '@/lib/common-queries/other';
 import nanoid from '@/lib/nanoid';
 import { getDateTime } from '@/utils';
 
@@ -30,6 +30,7 @@ const AddOrUpdate: React.FC<ISubCategoryAddOrUpdateProps> = ({
 	const { user } = useAuth();
 	const { data } = useSubCategoryByUUID(updatedData?.uuid as string);
 	const { data: category } = useOtherCategory<IFormSelectOption[]>();
+	const { invalidateQuery: invalidateQuerySubCategory } = useOtherSubCategory();
 
 	const form = useRHF(SUB_CATEGORY_SCHEMA, SUB_CATEGORY_NULL);
 
@@ -47,7 +48,6 @@ const AddOrUpdate: React.FC<ISubCategoryAddOrUpdateProps> = ({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data, isUpdate]);
 
-	console.log(form.formState.errors);
 	// Submit handler
 	async function onSubmit(values: ISubCategory) {
 		if (isUpdate) {
@@ -60,6 +60,7 @@ const AddOrUpdate: React.FC<ISubCategoryAddOrUpdateProps> = ({
 				},
 				onClose,
 			});
+			invalidateQuerySubCategory();
 		} else {
 			// ADD NEW ITEM
 			postData.mutateAsync({
@@ -72,6 +73,7 @@ const AddOrUpdate: React.FC<ISubCategoryAddOrUpdateProps> = ({
 				},
 				onClose,
 			});
+			invalidateQuerySubCategory();
 		}
 	}
 

--- a/src/pages/procurement/vendor/add-or-update.tsx
+++ b/src/pages/procurement/vendor/add-or-update.tsx
@@ -6,6 +6,7 @@ import { FormField } from '@/components/ui/form';
 import CoreForm from '@core/form';
 import { AddModal } from '@core/modal';
 
+import { useOtherVendor } from '@/lib/common-queries/other';
 import nanoid from '@/lib/nanoid';
 import { getDateTime } from '@/utils';
 
@@ -26,6 +27,7 @@ const AddOrUpdate: React.FC<IVendorAddOrUpdateProps> = ({
 
 	const { user } = useAuth();
 	const { data } = useVendorByUUID(updatedData?.uuid as string);
+	const { invalidateQuery: invalidateQueryVendor } = useOtherVendor();
 
 	const form = useRHF(VENDOR_SCHEMA, VENDOR_NULL);
 
@@ -55,6 +57,7 @@ const AddOrUpdate: React.FC<IVendorAddOrUpdateProps> = ({
 				},
 				onClose,
 			});
+			invalidateQueryVendor();
 		} else {
 			// ADD NEW ITEM
 			postData.mutateAsync({
@@ -67,6 +70,7 @@ const AddOrUpdate: React.FC<IVendorAddOrUpdateProps> = ({
 				},
 				onClose,
 			});
+			invalidateQueryVendor();
 		}
 	}
 


### PR DESCRIPTION
Introduce invalidate queries for categories, subcategories, purchase cost centers, and vendors to ensure data consistency after updates. This change enhances the responsiveness of the application by refreshing relevant data upon modifications.