### PR TITLE
Add CRUD functionality for Portfolio and Procurement sections

### DIFF
--- a/src/lib/common-queries/other/index.ts
+++ b/src/lib/common-queries/other/index.ts
@@ -80,3 +80,16 @@ export const useOtherVendor = <T>() =>
 		queryKey: otherQK.vendor(),
 		url: `/other/procure/vendor/value/label`,
 	});
+
+// * GET OTHER INTERNAL COST CENTER
+export const useOtherInternalCostCenter = <T>() =>
+	useTQuery<T>({
+		queryKey: otherQK.internalCostCenter(),
+		url: `/other/procure/internal-cost-center/value/label`,
+	});
+// * GET OTHER ITEM
+export const useOtherItem = <T>() =>
+	useTQuery<T>({
+		queryKey: otherQK.item(),
+		url: `/other/procure/item/value/label`,
+	});

--- a/src/lib/common-queries/other/query-keys.ts
+++ b/src/lib/common-queries/other/query-keys.ts
@@ -32,6 +32,11 @@ const otherQK = {
 
 	//* Vendor
 	vendor: () => [...otherQK.all(), 'vendor'],
+
+	//* Internal Cost Center
+	internalCostCenter: () => [...otherQK.all(), 'internalCostCenter'],
+	//* Item
+	item: () => [...otherQK.all(), 'item'],
 };
 
 export default otherQK;

--- a/src/pages/portfolio/feature/add-or-update.tsx
+++ b/src/pages/portfolio/feature/add-or-update.tsx
@@ -1,0 +1,118 @@
+import { useEffect } from 'react';
+import useAuth from '@/hooks/useAuth';
+import useRHF from '@/hooks/useRHF';
+
+import { FormField } from '@/components/ui/form';
+import CoreForm from '@core/form';
+import { AddModal } from '@core/modal';
+
+import nanoid from '@/lib/nanoid';
+import { getDateTime } from '@/utils';
+import Formdata from '@/utils/formdata';
+
+import { useFeatureByUUID } from './config/query';
+import { FEATURE_NULL, FEATURE_SCHEMA, IFeature } from './config/schema';
+import { IFeatureAddOrUpdateProps } from './config/types';
+
+const AddOrUpdate: React.FC<IFeatureAddOrUpdateProps> = ({
+	url,
+	open,
+	setOpen,
+	updatedData,
+	setUpdatedData,
+	imagePostData,
+	imageUpdateData,
+}) => {
+	const isUpdate = !!updatedData;
+
+	const { user } = useAuth();
+	const { data } = useFeatureByUUID(updatedData?.uuid as string);
+
+	const form = useRHF(FEATURE_SCHEMA, FEATURE_NULL);
+
+	const onClose = () => {
+		setUpdatedData?.(null);
+		form.reset(FEATURE_NULL);
+		setOpen((prev) => !prev);
+	};
+	// Reset form values when data is updated
+	useEffect(() => {
+		if (data && isUpdate) {
+			form.reset(data);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [data, isUpdate]);
+
+	// Submit handler
+	async function onSubmit(values: IFeature) {
+		const formData = Formdata<IFeature>(values);
+
+		if (isUpdate) {
+			formData.append('updated_at', getDateTime());
+
+			// UPDATE ITEM
+			await imageUpdateData.mutateAsync({
+				url: `${url}/${updatedData?.uuid}`,
+				updatedData: formData,
+				onClose,
+			});
+
+			return;
+		} else {
+			// ADD NEW ITEM
+			formData.append('created_at', getDateTime());
+			formData.append('created_by', user?.uuid || '');
+			formData.append('uuid', nanoid());
+
+			await imagePostData.mutateAsync({
+				url,
+				newData: formData,
+				onClose,
+			});
+		}
+	}
+
+	return (
+		<AddModal
+			isSmall
+			open={open}
+			setOpen={onClose}
+			title={isUpdate ? 'Update Feature' : 'Add Feature'}
+			form={form}
+			onSubmit={onSubmit}
+		>
+			<div className='grid grid-cols-1 gap-8 lg:grid-cols-3'>
+				<div className='col-span-2 space-y-4'>
+					<FormField
+						control={form.control}
+						name='is_active'
+						render={(props) => <CoreForm.Switch label='Active' {...props} />}
+					/>
+					<FormField
+						control={form.control}
+						name='index'
+						render={(props) => <CoreForm.Input type='number' {...props} />}
+					/>
+					<FormField control={form.control} name='title' render={(props) => <CoreForm.Input {...props} />} />
+					<FormField
+						control={form.control}
+						name='description'
+						render={(props) => <CoreForm.Textarea rows={4} {...props} />}
+					/>
+					<FormField
+						control={form.control}
+						name='remarks'
+						render={(props) => <CoreForm.Textarea {...props} />}
+					/>
+				</div>
+				<FormField
+					control={form.control}
+					name='file'
+					render={(props) => <CoreForm.FileUpload fileType='image' isUpdate={isUpdate} {...props} />}
+				/>
+			</div>
+		</AddModal>
+	);
+};
+
+export default AddOrUpdate;

--- a/src/pages/portfolio/feature/config/columns/columns.type.ts
+++ b/src/pages/portfolio/feature/config/columns/columns.type.ts
@@ -1,0 +1,11 @@
+// * Feature
+export type IFeatureTableData = {
+	id: number;
+	uuid: string;
+	index: number;
+	title: string;
+	description: string;
+	file: string;
+	is_active: boolean;
+	remarks: string;
+};

--- a/src/pages/portfolio/feature/config/columns/facetedFilters.tsx
+++ b/src/pages/portfolio/feature/config/columns/facetedFilters.tsx
@@ -1,0 +1,18 @@
+import { ITableFacetedFilter } from '@/types';
+
+export const type1FacetedFilters: ITableFacetedFilter[] = [
+	{
+		id: 'status',
+		title: 'Status',
+		options: [
+			{
+				label: 'Success',
+				value: 'success',
+			},
+			{
+				label: 'Failed',
+				value: 'failed',
+			},
+		],
+	},
+];

--- a/src/pages/portfolio/feature/config/columns/index.tsx
+++ b/src/pages/portfolio/feature/config/columns/index.tsx
@@ -1,0 +1,33 @@
+import { ColumnDef } from '@tanstack/react-table';
+
+import StatusButton from '@/components/buttons/status';
+import ColumnAvatar from '@/components/core/data-table/_views/column-avatar';
+
+import { IFeatureTableData } from './columns.type';
+
+// * Feature Columns
+export const featureColumns = (): ColumnDef<IFeatureTableData>[] => [
+	{
+		accessorKey: 'is_active',
+		header: 'Active',
+		enableColumnFilter: true,
+		cell: (info) => <StatusButton value={info.getValue() as number} />,
+	},
+
+	{
+		accessorKey: 'file',
+		header: 'Cover',
+		enableColumnFilter: true,
+		cell: (info) => <ColumnAvatar src={info.getValue() as string} alt={info.row.original.title} />,
+	},
+	{
+		accessorKey: 'title',
+		header: 'Title',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'description',
+		header: 'Description',
+		enableColumnFilter: true,
+	},
+];

--- a/src/pages/portfolio/feature/config/columns/index.tsx
+++ b/src/pages/portfolio/feature/config/columns/index.tsx
@@ -13,6 +13,11 @@ export const featureColumns = (): ColumnDef<IFeatureTableData>[] => [
 		enableColumnFilter: true,
 		cell: (info) => <StatusButton value={info.getValue() as number} />,
 	},
+	{
+		accessorKey: 'index',
+		header: 'Index',
+		enableColumnFilter: true,
+	},
 
 	{
 		accessorKey: 'file',

--- a/src/pages/portfolio/feature/config/query/index.ts
+++ b/src/pages/portfolio/feature/config/query/index.ts
@@ -1,0 +1,18 @@
+import useTQuery from '@/hooks/useTQuery';
+
+import { featureQK } from './queryKeys';
+
+// ? INQUIRY
+// * ALL
+export const useFeature = <T>() =>
+	useTQuery<T>({
+		queryKey: featureQK.feature(),
+		url: `/portfolio/feature?is_pagination=false`,
+	});
+
+export const useFeatureByUUID = <T>(uuid: string) =>
+	useTQuery<T>({
+		queryKey: featureQK.featureByUUID(uuid),
+		url: `/portfolio/feature/${uuid}`,
+		enabled: !!uuid,
+	});

--- a/src/pages/portfolio/feature/config/query/queryKeys.ts
+++ b/src/pages/portfolio/feature/config/query/queryKeys.ts
@@ -1,0 +1,7 @@
+export const featureQK = {
+	all: () => ['portfolio'],
+
+	// * Feature
+	feature: () => [...featureQK.all(), 'feature'],
+	featureByUUID: (uuid: string) => [...featureQK.feature(), uuid],
+};

--- a/src/pages/portfolio/feature/config/schema/index.ts
+++ b/src/pages/portfolio/feature/config/schema/index.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+import { STRING_NULLABLE, STRING_REQUIRED } from '@/utils/validators';
+
+//* Form Schema
+export const FEATURE_SCHEMA = z.object({
+	index: z.number(),
+	is_active: z.boolean(),
+	title: STRING_REQUIRED,
+	description: STRING_REQUIRED,
+	file: z
+		.instanceof(File)
+		.refine((file) => file?.size !== 0, 'Please upload an image')
+		.or(STRING_NULLABLE),
+	remarks: STRING_NULLABLE,
+});
+
+export const FEATURE_NULL: Partial<IFeature> = {
+	index: 0,
+	is_active: true,
+	title: '',
+	description: '',
+	file: new File([''], 'filename') as File,
+	remarks: '',
+};
+
+export type IFeature = z.infer<typeof FEATURE_SCHEMA>;

--- a/src/pages/portfolio/feature/config/types/index.tsx
+++ b/src/pages/portfolio/feature/config/types/index.tsx
@@ -1,0 +1,10 @@
+import { IDefaultFileAddOrUpdateProps } from '@/types';
+
+import '../columns/columns.type';
+
+import { IFeatureTableData } from '../columns/columns.type';
+
+//* Feature
+export interface IFeatureAddOrUpdateProps extends IDefaultFileAddOrUpdateProps {
+	updatedData?: IFeatureTableData | null;
+}

--- a/src/pages/portfolio/feature/index.tsx
+++ b/src/pages/portfolio/feature/index.tsx
@@ -1,0 +1,96 @@
+import { lazy, useMemo, useState } from 'react';
+import { PageProvider, TableProvider } from '@/context';
+import { Row } from '@tanstack/react-table';
+
+import { PageInfo } from '@/utils';
+import renderSuspenseModals from '@/utils/renderSuspenseModals';
+
+import { featureColumns } from './config/columns';
+import { IFeatureTableData } from './config/columns/columns.type';
+import { useFeature } from './config/query';
+
+const AddOrUpdate = lazy(() => import('./add-or-update'));
+const DeleteModal = lazy(() => import('@core/modal/delete'));
+
+const Feature = () => {
+	const { data, isLoading, url, deleteData, postData, updateData, imagePostData, imageUpdateData, refetch } =
+		useFeature<IFeatureTableData[]>();
+
+	const pageInfo = useMemo(() => new PageInfo('Feature', url, 'portfolio__feature'), [url]);
+
+	// Add/Update Modal state
+	const [isOpenAddModal, setIsOpenAddModal] = useState(false);
+
+	const handleCreate = () => {
+		setIsOpenAddModal(true);
+	};
+
+	const [updatedData, setUpdatedData] = useState<IFeatureTableData | null>(null);
+	const handleUpdate = (row: Row<IFeatureTableData>) => {
+		setUpdatedData(row.original);
+		setIsOpenAddModal(true);
+	};
+
+	// Delete Modal state
+	const [deleteItem, setDeleteItem] = useState<{
+		id: string;
+		name: string;
+	} | null>(null);
+
+	const handleDelete = (row: Row<IFeatureTableData>) => {
+		setDeleteItem({
+			id: row?.original?.uuid,
+			name: row?.original?.title,
+		});
+	};
+
+	// Table Columns
+	const columns = featureColumns();
+
+	return (
+		<PageProvider pageName={pageInfo.getTab()} pageTitle={pageInfo.getTabName()}>
+			<TableProvider
+				defaultVisibleColumns={{
+					created_by_name: false,
+					created_at: false,
+					updated_at: false,
+				}}
+				title={pageInfo.getTitle()}
+				columns={columns}
+				data={data ?? []}
+				isLoading={isLoading}
+				handleCreate={handleCreate}
+				handleUpdate={handleUpdate}
+				handleDelete={handleDelete}
+				handleRefetch={refetch}
+			>
+				{renderSuspenseModals([
+					<AddOrUpdate
+						{...{
+							url: '/portfolio/feature',
+							open: isOpenAddModal,
+							setOpen: setIsOpenAddModal,
+							updatedData,
+							setUpdatedData,
+							postData,
+							updateData,
+							imagePostData,
+							imageUpdateData,
+						}}
+					/>,
+
+					<DeleteModal
+						{...{
+							deleteItem,
+							setDeleteItem,
+							url: '/portfolio/feature',
+							deleteData,
+						}}
+					/>,
+				])}
+			</TableProvider>
+		</PageProvider>
+	);
+};
+
+export default Feature;

--- a/src/pages/procurement/internal-cost-center/add-or-update.tsx
+++ b/src/pages/procurement/internal-cost-center/add-or-update.tsx
@@ -1,0 +1,113 @@
+import { useEffect } from 'react';
+import useAuth from '@/hooks/useAuth';
+import useRHF from '@/hooks/useRHF';
+
+import { IFormSelectOption } from '@/components/core/form/types';
+import { FormField } from '@/components/ui/form';
+import CoreForm from '@core/form';
+import { AddModal } from '@core/modal';
+
+import { useOtherCategory, useOtherUser } from '@/lib/common-queries/other';
+import nanoid from '@/lib/nanoid';
+import { getDateTime } from '@/utils';
+
+import { useInternalCostCenterByUUID } from './config/query';
+import { IInternalCostCenter, INTERNAL_COST_CENTER_NULL, INTERNAL_COST_CENTER_SCHEMA } from './config/schema';
+import { IInternalCostCenterAddOrUpdateProps } from './config/types';
+import { types } from './utils';
+
+const AddOrUpdate: React.FC<IInternalCostCenterAddOrUpdateProps> = ({
+	url,
+	open,
+	setOpen,
+	updatedData,
+	setUpdatedData,
+	postData,
+	updateData,
+}) => {
+	const isUpdate = !!updatedData;
+
+	const { user } = useAuth();
+	const { data } = useInternalCostCenterByUUID(updatedData?.uuid as string);
+	const { invalidateQuery: invalidateQueryCategory } = useOtherCategory();
+	const { data: userOption } = useOtherUser<IFormSelectOption[]>();
+
+	const form = useRHF(INTERNAL_COST_CENTER_SCHEMA, INTERNAL_COST_CENTER_NULL);
+
+	const onClose = () => {
+		setUpdatedData?.(null);
+		form.reset(INTERNAL_COST_CENTER_NULL);
+		setOpen((prev) => !prev);
+	};
+
+	// Reset form values when data is updated
+	useEffect(() => {
+		if (data && isUpdate) {
+			form.reset(data);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [data, isUpdate]);
+
+	// Submit handler
+	async function onSubmit(values: IInternalCostCenter) {
+		if (isUpdate) {
+			// UPDATE ITEM
+			updateData.mutateAsync({
+				url: `${url}/${updatedData?.uuid}`,
+				updatedData: {
+					...values,
+					updated_at: getDateTime(),
+				},
+				onClose,
+			});
+			invalidateQueryCategory();
+		} else {
+			// ADD NEW ITEM
+			postData.mutateAsync({
+				url,
+				newData: {
+					...values,
+					created_at: getDateTime(),
+					created_by: user?.uuid,
+					uuid: nanoid(),
+				},
+				onClose,
+			});
+			invalidateQueryCategory();
+		}
+	}
+
+	return (
+		<AddModal
+			open={open}
+			setOpen={onClose}
+			title={isUpdate ? 'Update Internal Cost Center' : 'Add Internal Cost Center'}
+			form={form}
+			onSubmit={onSubmit}
+		>
+			<FormField control={form.control} name='name' render={(props) => <CoreForm.Input {...props} />} />
+			<FormField
+				control={form.control}
+				name='authorized_person_uuid'
+				render={(props) => <CoreForm.ReactSelect label='Authorized Person' options={userOption!} {...props} />}
+			/>
+			<FormField
+				control={form.control}
+				name='type'
+				render={(props) => (
+					<CoreForm.ReactSelect label='Type' placeholder='Select Type' options={types!} {...props} />
+				)}
+			/>
+			<FormField control={form.control} name='from' render={(props) => <CoreForm.DatePicker {...props} />} />
+			<FormField control={form.control} name='to' render={(props) => <CoreForm.DatePicker {...props} />} />
+			<FormField
+				control={form.control}
+				name='budget'
+				render={(props) => <CoreForm.Input type='number' {...props} />}
+			/>
+			<FormField control={form.control} name='remarks' render={(props) => <CoreForm.Textarea {...props} />} />
+		</AddModal>
+	);
+};
+
+export default AddOrUpdate;

--- a/src/pages/procurement/internal-cost-center/config/columns/columns.type.ts
+++ b/src/pages/procurement/internal-cost-center/config/columns/columns.type.ts
@@ -1,0 +1,11 @@
+// * Internal Cost Center
+export type IInternalCostCenterTableData = {
+	uuid: string;
+	type: 'proctor' | 'admission' | 'exam_control' | 'fed' | 'purchase_committee';
+	authorized_person_uuid: string;
+	name: string;
+	from: string;
+	to: string;
+	budget: number;
+	remarks: string;
+};

--- a/src/pages/procurement/internal-cost-center/config/columns/facetedFilters.tsx
+++ b/src/pages/procurement/internal-cost-center/config/columns/facetedFilters.tsx
@@ -1,0 +1,18 @@
+import { ITableFacetedFilter } from '@/types';
+
+export const type1FacetedFilters: ITableFacetedFilter[] = [
+	{
+		id: 'status',
+		title: 'Status',
+		options: [
+			{
+				label: 'Success',
+				value: 'success',
+			},
+			{
+				label: 'Failed',
+				value: 'failed',
+			},
+		],
+	},
+];

--- a/src/pages/procurement/internal-cost-center/config/columns/index.tsx
+++ b/src/pages/procurement/internal-cost-center/config/columns/index.tsx
@@ -1,0 +1,41 @@
+import { ColumnDef } from '@tanstack/react-table';
+
+import DateTime from '@/components/ui/date-time';
+
+import { IInternalCostCenterTableData } from './columns.type';
+
+// * Internal Cost Center Columns
+export const internalCostCenterColumns = (): ColumnDef<IInternalCostCenterTableData>[] => [
+	{
+		accessorKey: 'name',
+		header: 'Name',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'authorized_person_name',
+		header: 'Authorized Person',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'type',
+		header: 'Type',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'from',
+		header: 'From',
+		enableColumnFilter: true,
+		cell: (info) => <DateTime isTime={false} date={info.getValue() as Date} />,
+	},
+	{
+		accessorKey: 'to',
+		header: 'To',
+		enableColumnFilter: true,
+		cell: (info) => <DateTime isTime={false} date={info.getValue() as Date} />,
+	},
+	{
+		accessorKey: 'budget',
+		header: 'Budget',
+		enableColumnFilter: true,
+	},
+];

--- a/src/pages/procurement/internal-cost-center/config/query/index.ts
+++ b/src/pages/procurement/internal-cost-center/config/query/index.ts
@@ -1,0 +1,17 @@
+import useTQuery from '@/hooks/useTQuery';
+
+import { internalCostCenterQK } from './queryKeys';
+
+// * Internal Cost Center
+export const useInternalCostCenter = <T>() =>
+	useTQuery<T>({
+		queryKey: internalCostCenterQK.internalCostCenter(),
+		url: `/procure/internal-cost-center`,
+	});
+
+export const useInternalCostCenterByUUID = <T>(uuid: string) =>
+	useTQuery<T>({
+		queryKey: internalCostCenterQK.internalCostCenterByUUID(uuid),
+		url: `/procure/internal-cost-center/${uuid}`,
+		enabled: !!uuid,
+	});

--- a/src/pages/procurement/internal-cost-center/config/query/queryKeys.ts
+++ b/src/pages/procurement/internal-cost-center/config/query/queryKeys.ts
@@ -1,0 +1,7 @@
+export const internalCostCenterQK = {
+	all: () => ['procure'],
+
+	// * internalCostCenter
+	internalCostCenter: () => [...internalCostCenterQK.all(), 'internal-cost-center'],
+	internalCostCenterByUUID: (uuid: string) => [...internalCostCenterQK.internalCostCenter(), uuid],
+};

--- a/src/pages/procurement/internal-cost-center/config/schema/index.ts
+++ b/src/pages/procurement/internal-cost-center/config/schema/index.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+import { BOOLEAN_REQUIRED, NUMBER_REQUIRED, STRING_NULLABLE, STRING_REQUIRED } from '@/utils/validators';
+
+// * Internal Cost Center Schema
+export const INTERNAL_COST_CENTER_SCHEMA = z.object({
+	name: STRING_REQUIRED,
+	authorized_person_uuid: STRING_REQUIRED,
+	from: STRING_REQUIRED,
+	to: STRING_REQUIRED,
+	type: z.enum(['proctor', 'admission', 'exam-control', 'fed', 'purchase_committee']),
+	budget: NUMBER_REQUIRED,
+	remarks: STRING_NULLABLE,
+});
+
+export const INTERNAL_COST_CENTER_NULL: Partial<IInternalCostCenter> = {
+	name: '',
+	authorized_person_uuid: '',
+	from: '',
+	to: '',
+	type: undefined,
+	budget: 0,
+	remarks: '',
+};
+
+export type IInternalCostCenter = z.infer<typeof INTERNAL_COST_CENTER_SCHEMA>;

--- a/src/pages/procurement/internal-cost-center/config/types/index.tsx
+++ b/src/pages/procurement/internal-cost-center/config/types/index.tsx
@@ -1,0 +1,10 @@
+import { IDefaultAddOrUpdateProps } from '@/types';
+
+import '../columns/columns.type';
+
+import { IInternalCostCenterTableData } from '../columns/columns.type';
+
+//* Internal Cost Center
+export interface IInternalCostCenterAddOrUpdateProps extends IDefaultAddOrUpdateProps {
+	updatedData?: IInternalCostCenterTableData | null;
+}

--- a/src/pages/procurement/internal-cost-center/index.tsx
+++ b/src/pages/procurement/internal-cost-center/index.tsx
@@ -1,0 +1,92 @@
+import { lazy, useMemo, useState } from 'react';
+import { PageProvider, TableProvider } from '@/context';
+import { Row } from '@tanstack/react-table';
+
+import { PageInfo } from '@/utils';
+import renderSuspenseModals from '@/utils/renderSuspenseModals';
+
+import { internalCostCenterColumns } from './config/columns';
+import { IInternalCostCenterTableData } from './config/columns/columns.type';
+import { useInternalCostCenter } from './config/query';
+
+const AddOrUpdate = lazy(() => import('./add-or-update'));
+const DeleteModal = lazy(() => import('@core/modal/delete'));
+
+const InternalCostCenter = () => {
+	const { data, isLoading, url, deleteData, postData, updateData, refetch } =
+		useInternalCostCenter<IInternalCostCenterTableData[]>();
+
+	const pageInfo = useMemo(
+		() => new PageInfo('Internal Cost Center', url, 'procurement__internal_cost_center'),
+		[url]
+	);
+
+	// Add/Update Modal state
+	const [isOpenAddModal, setIsOpenAddModal] = useState(false);
+
+	const handleCreate = () => {
+		setIsOpenAddModal(true);
+	};
+
+	const [updatedData, setUpdatedData] = useState<IInternalCostCenterTableData | null>(null);
+	const handleUpdate = (row: Row<IInternalCostCenterTableData>) => {
+		setUpdatedData(row.original);
+		setIsOpenAddModal(true);
+	};
+
+	// Delete Modal state
+	const [deleteItem, setDeleteItem] = useState<{
+		id: string;
+		name: string;
+	} | null>(null);
+
+	const handleDelete = (row: Row<IInternalCostCenterTableData>) => {
+		setDeleteItem({
+			id: row?.original?.uuid,
+			name: row?.original?.name,
+		});
+	};
+
+	// Table Columns
+	const columns = internalCostCenterColumns();
+
+	return (
+		<PageProvider pageName={pageInfo.getTab()} pageTitle={pageInfo.getTabName()}>
+			<TableProvider
+				title={pageInfo.getTitle()}
+				columns={columns}
+				data={data ?? []}
+				isLoading={isLoading}
+				handleCreate={handleCreate}
+				handleUpdate={handleUpdate}
+				handleDelete={handleDelete}
+				handleRefetch={refetch}
+			>
+				{renderSuspenseModals([
+					<AddOrUpdate
+						{...{
+							url,
+							open: isOpenAddModal,
+							setOpen: setIsOpenAddModal,
+							updatedData,
+							setUpdatedData,
+							postData,
+							updateData,
+						}}
+					/>,
+
+					<DeleteModal
+						{...{
+							deleteItem,
+							setDeleteItem,
+							url,
+							deleteData,
+						}}
+					/>,
+				])}
+			</TableProvider>
+		</PageProvider>
+	);
+};
+
+export default InternalCostCenter;

--- a/src/pages/procurement/internal-cost-center/utils.ts
+++ b/src/pages/procurement/internal-cost-center/utils.ts
@@ -1,0 +1,7 @@
+export const types = [
+	{ label: 'Proctor', value: 'proctor' },
+	{ label: 'Admission', value: 'admission' },
+	{ label: 'Exam Control', value: 'exam-control' },
+	{ label: 'Fed', value: 'fed' },
+	{ label: 'purchase_committee', value: 'purchase_committee' },
+];

--- a/src/pages/procurement/item/config/schema/index.ts
+++ b/src/pages/procurement/item/config/schema/index.ts
@@ -12,7 +12,6 @@ import {
 
 // Item Schema
 export const ITEM_SCHEMA = z.object({
-	index: NUMBER_REQUIRED,
 	name: STRING_REQUIRED,
 	purchase_cost_center_uuid: STRING_REQUIRED,
 	vendor_price: NUMBER_REQUIRED.min(1, 'Vendor Price must be greater than 0'),
@@ -24,7 +23,6 @@ export const ITEM_SCHEMA = z.object({
 });
 
 export const ITEM_NULL: Partial<IItem> = {
-	index: 0,
 	name: '',
 	purchase_cost_center_uuid: '',
 	vendor_price: 0,

--- a/src/pages/procurement/item/entry.tsx
+++ b/src/pages/procurement/item/entry.tsx
@@ -183,11 +183,6 @@ const Entry = () => {
 	return (
 		<CoreForm.AddEditWrapper title={isUpdate ? 'Edit Item' : 'Add Item'} form={form} onSubmit={onSubmit}>
 			<CoreForm.Section title={`Items`}>
-				<FormField
-					control={form.control}
-					name='index'
-					render={(props) => <CoreForm.Input {...props} type='number' />}
-				/>
 				<FormField control={form.control} name='name' render={(props) => <CoreForm.Input {...props} />} />
 				<FormField
 					control={form.control}

--- a/src/pages/procurement/requisition/config/columns/columns.type.ts
+++ b/src/pages/procurement/requisition/config/columns/columns.type.ts
@@ -1,0 +1,52 @@
+// * Requisition
+export type IRequisitionTableData = {
+	uuid: string;
+	id: number;
+	internal_cost_center_uuid: string;
+	internal_cost_center_name: string;
+	is_received: boolean;
+	received_date: string;
+	department:
+		| 'chairman_bot'
+		| 'vice_chancellor'
+		| 'treasurer'
+		| 'pni'
+		| 'pnd'
+		| 'civil_engineering'
+		| 'admission_office'
+		| 'controller_office'
+		| 'exam_c_01'
+		| 'exam_c_02'
+		| 'account_c_01'
+		| 'account_c_02'
+		| 'cse'
+		| 'registrar(hod)'
+		| 'additional_registrar'
+		| 'additional_registrar_c_01'
+		| 'additional_registrar_c_02'
+		| 'english'
+		| 'businessadministration'
+		| 'library '
+		| 'ipe&_iqac'
+		| 'textile_engineering'
+		| 'proctor_office'
+		| 'eee'
+		| 'fde'
+		| 'medical_centre'
+		| 'economics'
+		| 'mdgs'
+		| 'thm'
+		| 'mathematics'
+		| 'pcu'
+		| 'program_coordination_manager'
+		| 'program_coordination_asst_manager'
+		| 'sr_program_coordination_incharge'
+		| 'physics'
+		| 'chemistry'
+		| 'security_director'
+		| 'logistics'
+		| 'reception_gate'
+		| 'ict'
+		| 'law';
+	remarks: string;
+};

--- a/src/pages/procurement/requisition/config/columns/facetedFilters.tsx
+++ b/src/pages/procurement/requisition/config/columns/facetedFilters.tsx
@@ -1,0 +1,18 @@
+import { ITableFacetedFilter } from '@/types';
+
+export const type1FacetedFilters: ITableFacetedFilter[] = [
+	{
+		id: 'status',
+		title: 'Status',
+		options: [
+			{
+				label: 'Success',
+				value: 'success',
+			},
+			{
+				label: 'Failed',
+				value: 'failed',
+			},
+		],
+	},
+];

--- a/src/pages/procurement/requisition/config/columns/index.tsx
+++ b/src/pages/procurement/requisition/config/columns/index.tsx
@@ -1,0 +1,33 @@
+import { ColumnDef } from '@tanstack/react-table';
+
+import StatusButton from '@/components/buttons/status';
+import DateTime from '@/components/ui/date-time';
+
+import { cn } from '@/lib/utils';
+
+import { IRequisitionTableData } from './columns.type';
+
+// * Requisition Table Columns
+export const requisitionColumns = (): ColumnDef<IRequisitionTableData>[] => [
+	{
+		accessorKey: 'internal_cost_center_name',
+		header: 'Internal Cost Center',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'is_received',
+		header: 'Received',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'received_date',
+		header: 'Price Validity',
+		enableColumnFilter: true,
+		cell: (info) => <DateTime date={info.getValue() as Date} isTime={false} />,
+	},
+	{
+		accessorKey: 'department',
+		header: 'Department',
+		enableColumnFilter: true,
+	},
+];

--- a/src/pages/procurement/requisition/config/query/index.ts
+++ b/src/pages/procurement/requisition/config/query/index.ts
@@ -1,0 +1,24 @@
+import useTQuery from '@/hooks/useTQuery';
+
+import { requisitionQK } from './queryKeys';
+
+// * REQUISITION
+export const useRequisition = <T>() =>
+	useTQuery<T>({
+		queryKey: requisitionQK.requisition(),
+		url: `/procure/requisition`,
+	});
+
+export const useRequisitionByUUID = <T>(uuid: string) =>
+	useTQuery<T>({
+		queryKey: requisitionQK.requisitionByUUID(uuid),
+		url: `/procure/requisition/${uuid}`,
+		enabled: !!uuid,
+	});
+
+export const useRequisitionAndItemByUUID = <T>(uuid: string) =>
+	useTQuery<T>({
+		queryKey: requisitionQK.requisitionAndItemByUUID(uuid),
+		url: `/procure/item-requisition-details/by/${uuid}`,
+		enabled: !!uuid,
+	});

--- a/src/pages/procurement/requisition/config/query/queryKeys.ts
+++ b/src/pages/procurement/requisition/config/query/queryKeys.ts
@@ -1,0 +1,8 @@
+export const requisitionQK = {
+	all: () => ['procure'],
+
+	// * Requisition
+	requisition: () => [...requisitionQK.all(), 'requisition'],
+	requisitionByUUID: (uuid: string) => [...requisitionQK.requisition(), uuid],
+	requisitionAndItemByUUID: (uuid: string) => [...requisitionQK.all(), 'requisition', 'item', uuid],
+};

--- a/src/pages/procurement/requisition/config/schema/index.ts
+++ b/src/pages/procurement/requisition/config/schema/index.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+
+import {
+	BOOLEAN_REQUIRED,
+	NUMBER_REQUIRED,
+	PHONE_NUMBER_OPTIONAL,
+	PHONE_NUMBER_REQUIRED,
+	STRING_NULLABLE,
+	STRING_OPTIONAL,
+	STRING_REQUIRED,
+} from '@/utils/validators';
+
+// Requisition Schema
+export const REQUISITION_SCHEMA = z
+	.object({
+		internal_cost_center_uuid: STRING_REQUIRED,
+		is_received: BOOLEAN_REQUIRED.default(false),
+		received_date: STRING_OPTIONAL,
+		department: z.enum([
+			'chairman_bot',
+			'vice_chancellor',
+			'treasurer',
+			'pni',
+			'pnd',
+			'civil_engineering',
+			'admission_office',
+			'controller_office',
+			'exam_c_01',
+			'exam_c_02',
+			'account_c_01',
+			'account_c_02',
+			'cse',
+			'registrar(hod)',
+			'additional_registrar',
+			'additional_registrar_c_01',
+			'additional_registrar_c_02',
+			'english',
+			'businessadministration',
+			'library ',
+			'ipe&_iqac',
+			'textile_engineering',
+			'proctor_office',
+			'eee',
+			'fde',
+			'medical_centre',
+			'economics',
+			'mdgs',
+			'thm',
+			'mathematics ',
+			'pcu',
+			'program_coordination_manager',
+			'program_coordination_asst_manager',
+			'sr_program_coordination_incharge',
+			'physics',
+			'chemistry',
+			'security_director',
+			'logistics',
+			'reception_gate',
+			'ict',
+			'law',
+		]),
+		remarks: STRING_NULLABLE,
+		item_requisition: z.array(
+			z.object({
+				uuid: STRING_OPTIONAL,
+				requisition_uuid: STRING_OPTIONAL,
+				item_uuid: STRING_REQUIRED,
+				req_quantity: NUMBER_REQUIRED.min(1, 'Must be greater than 0'),
+				provided_quantity: NUMBER_REQUIRED,
+				remarks: STRING_NULLABLE,
+			})
+		),
+	})
+	.superRefine((data, ctx) => {
+		if (data.is_received && !data.received_date) {
+			ctx.addIssue({
+				code: 'custom',
+				message: 'Received Date is required',
+			});
+		}
+	});
+
+export const REQUISITION_NULL: Partial<IRequisition> = {
+	internal_cost_center_uuid: '',
+	is_received: false,
+	received_date: '',
+	department: undefined,
+	remarks: '',
+	item_requisition: [],
+};
+
+export type IRequisition = z.infer<typeof REQUISITION_SCHEMA>;

--- a/src/pages/procurement/requisition/config/types/index.tsx
+++ b/src/pages/procurement/requisition/config/types/index.tsx
@@ -1,0 +1,12 @@
+import { IDefaultAddOrUpdateProps, IDefaultFileAddOrUpdateProps, IToast } from '@/types';
+import { UseMutationResult } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import '../columns/columns.type';
+
+import { IRequisitionTableData } from '../columns/columns.type';
+
+//* Requisition
+export interface IRequisitionAddOrUpdateProps extends IDefaultAddOrUpdateProps {
+	updatedData?: IRequisitionTableData | null;
+}

--- a/src/pages/procurement/requisition/entry.tsx
+++ b/src/pages/procurement/requisition/entry.tsx
@@ -1,0 +1,276 @@
+import { Suspense, useEffect, useState } from 'react';
+import { divide } from 'lodash';
+import { useFieldArray } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router-dom';
+import useAuth from '@/hooks/useAuth';
+import useRHF from '@/hooks/useRHF';
+
+import { IFormSelectOption } from '@/components/core/form/types';
+import { FormField } from '@/components/ui/form';
+import CoreForm from '@core/form';
+import { DeleteModal } from '@core/modal';
+
+import { useOtherInternalCostCenter } from '@/lib/common-queries/other';
+import nanoid from '@/lib/nanoid';
+import { getDateTime } from '@/utils';
+
+import { IRequisitionTableData } from './config/columns/columns.type';
+import { useRequisition, useRequisitionAndItemByUUID } from './config/query';
+import { IRequisition, REQUISITION_NULL, REQUISITION_SCHEMA } from './config/schema';
+import useGenerateFieldDefs from './useGenerateFieldDefs';
+import { departments } from './utils';
+
+const Entry = () => {
+	const { uuid } = useParams();
+	const isUpdate = !!uuid;
+	const navigate = useNavigate();
+
+	const { user } = useAuth();
+	const {
+		data,
+		updateData,
+		postData,
+		deleteData,
+		invalidateQuery: invalidateQueryRequisition,
+	} = useRequisitionAndItemByUUID(uuid as string);
+	const { invalidateQuery } = useRequisition<IRequisitionTableData[]>();
+	const { data: internalCostCenter, invalidateQuery: invalidateQueryInternalCostCenter } =
+		useOtherInternalCostCenter<IFormSelectOption[]>();
+
+	const form = useRHF(REQUISITION_SCHEMA, REQUISITION_NULL);
+	const { fields, append, remove } = useFieldArray({
+		control: form.control,
+		name: 'item_requisition',
+	});
+
+	// Reset form values when data is updated
+	useEffect(() => {
+		if (data && isUpdate) {
+			form.reset(data);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [data, isUpdate]);
+
+	// Submit handler
+	async function onSubmit(values: IRequisition) {
+		if (isUpdate) {
+			// UPDATE ITEM
+			const { item_requisition, ...rest } = values;
+			const itemUpdatedData = {
+				...rest,
+				updated_at: getDateTime(),
+			};
+
+			updateData
+				.mutateAsync({
+					url: `/procure/requisition/${uuid}`,
+					updatedData: itemUpdatedData,
+				})
+				.then(() => {
+					const entryUpdatePromise = item_requisition.map((entry) => {
+						if (entry.uuid) {
+							const entryUpdateData = {
+								...entry,
+								updatedData: itemUpdatedData,
+							};
+							return updateData.mutateAsync({
+								url: `/procure/item-requisition/${entry.uuid}`,
+								updatedData: entryUpdateData,
+							});
+						} else {
+							const entryData = {
+								...entry,
+								created_at: getDateTime(),
+								created_by: user?.uuid,
+								uuid: nanoid(),
+								requisition_uuid: uuid,
+							};
+
+							return postData.mutateAsync({
+								url: `/procure/item-requisition`,
+								newData: entryData,
+							});
+						}
+					});
+
+					Promise.all(entryUpdatePromise);
+				})
+				.then(() => {
+					invalidateQuery();
+					invalidateQueryRequisition();
+					invalidateQueryInternalCostCenter();
+					navigate('/procurement/requisition');
+				})
+				.catch((error) => {
+					console.error('Error updating news:', error);
+				});
+		} else {
+			// ADD NEW ITEM
+			const { item_requisition, ...rest } = values;
+			const itemData = {
+				...rest,
+				created_at: getDateTime(),
+				created_by: user?.uuid,
+				uuid: nanoid(),
+			};
+
+			postData
+				.mutateAsync({
+					url: '/procure/requisition',
+					newData: itemData,
+				})
+				.then(() => {
+					const entryPromise = item_requisition.map((entry) => {
+						const entryData = {
+							...entry,
+							created_at: getDateTime(),
+							created_by: user?.uuid,
+							uuid: nanoid(),
+							requisition_uuid: itemData.uuid,
+						};
+
+						return postData.mutateAsync({
+							url: `/procure/item-requisition`,
+							newData: entryData,
+						});
+					});
+
+					Promise.all([...entryPromise]);
+				})
+				.then(() => {
+					invalidateQuery();
+					invalidateQueryRequisition();
+					invalidateQueryInternalCostCenter();
+					navigate('/procurement/requisition');
+				})
+				.catch((error) => {
+					console.error('Error adding news:', error);
+				});
+		}
+	}
+
+	const handleAdd = () => {
+		// TODO: Update field names
+
+		append({
+			item_uuid: '',
+			req_quantity: 0,
+			provided_quantity: 0,
+			remarks: '',
+		});
+	};
+
+	const [deleteItem, setDeleteItem] = useState<{
+		id: string;
+		name: string;
+	} | null>(null);
+
+	const handleRemove = (index: number) => {
+		if (fields[index].uuid) {
+			setDeleteItem({
+				id: fields[index].uuid, // TODO: Update field id
+				name: fields[index].id, // TODO: Update field name
+			});
+		} else {
+			remove(index);
+		}
+	};
+
+	// Copy Handler
+	const handleCopy = (index: number) => {
+		// TODO: Update fields ⬇️
+		const field = form.watch('item_requisition')[index];
+		append({
+			item_uuid: field.item_uuid,
+			req_quantity: field.req_quantity,
+			provided_quantity: field.provided_quantity,
+			remarks: field.remarks,
+		});
+	};
+
+	return (
+		<CoreForm.AddEditWrapper
+			title={isUpdate ? 'Edit Requisition' : 'Add Requisition'}
+			form={form}
+			onSubmit={onSubmit}
+		>
+			<CoreForm.Section
+				title={`Requisition`}
+				extraHeader={
+					<div className='flex gap-4 text-white'>
+						<FormField
+							control={form.control}
+							name='is_received'
+							render={(props) => <CoreForm.Switch label='Received' {...props} />}
+						/>
+						<FormField
+							control={form.control}
+							name='received_date'
+							render={(props) => <CoreForm.DatePicker placeholder='Received Date' {...props} />}
+						/>
+					</div>
+				}
+			>
+				<FormField
+					control={form.control}
+					name='internal_cost_center_uuid'
+					render={(props) => (
+						<CoreForm.ReactSelect
+							label='Internal Cost Center'
+							placeholder='Select Internal Cost Center'
+							options={internalCostCenter!}
+							{...props}
+						/>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name='department'
+					render={(props) => (
+						<CoreForm.ReactSelect
+							label='Department'
+							placeholder='Select Department'
+							options={departments}
+							{...props}
+						/>
+					)}
+				/>
+				<FormField control={form.control} name='remarks' render={(props) => <CoreForm.Textarea {...props} />} />
+			</CoreForm.Section>
+			<CoreForm.DynamicFields
+				title='Item Requisition'
+				form={form}
+				fieldName='item_requisition'
+				fieldDefs={useGenerateFieldDefs({
+					data: form.getValues(),
+					copy: handleCopy,
+					remove: handleRemove,
+					isUpdate,
+				})}
+				handleAdd={handleAdd}
+				fields={fields}
+			/>
+			<Suspense fallback={null}>
+				<DeleteModal
+					{...{
+						deleteItem,
+						setDeleteItem,
+						url: `/procure/item-requisition`, // TODO: Update url
+						deleteData,
+						onClose: () => {
+							form.setValue(
+								'item_requisition', // TODO: Update field name
+								form
+									.getValues('item_requisition') // TODO: Update field name
+									.filter((item) => item.uuid !== deleteItem?.id)
+							);
+						},
+					}}
+				/>
+			</Suspense>
+		</CoreForm.AddEditWrapper>
+	);
+};
+
+export default Entry;

--- a/src/pages/procurement/requisition/index.tsx
+++ b/src/pages/procurement/requisition/index.tsx
@@ -1,0 +1,74 @@
+import { lazy, useMemo, useState } from 'react';
+import { PageProvider, TableProvider } from '@/context';
+import { Row } from '@tanstack/react-table';
+import { useNavigate } from 'react-router-dom';
+
+import { PageInfo } from '@/utils';
+import renderSuspenseModals from '@/utils/renderSuspenseModals';
+
+import { requisitionColumns } from './config/columns';
+import { IRequisitionTableData } from './config/columns/columns.type';
+import { useRequisition } from './config/query';
+
+const DeleteModal = lazy(() => import('@core/modal/delete'));
+
+const Requisition = () => {
+	const navigate = useNavigate();
+	const { data, isLoading, url, deleteData, refetch } = useRequisition<IRequisitionTableData[]>();
+
+	const pageInfo = useMemo(() => new PageInfo('Requisition', url, 'procurement__requisition'), [url]);
+
+	// Add/Update Modal state
+
+	const handleCreate = () => {
+		navigate('/procurement/requisition/create');
+	};
+
+	const handleUpdate = (row: Row<IRequisitionTableData>) => {
+		navigate(`/procurement/requisition/${row.original.uuid}/update`);
+	};
+
+	// Delete Modal state
+	const [deleteItem, setDeleteItem] = useState<{
+		id: string;
+		name: string;
+	} | null>(null);
+
+	const handleDelete = (row: Row<IRequisitionTableData>) => {
+		setDeleteItem({
+			id: row?.original?.uuid,
+			name: row?.original?.internal_cost_center_name,
+		});
+	};
+
+	// Table Columns
+	const columns = requisitionColumns();
+
+	return (
+		<PageProvider pageName={pageInfo.getTab()} pageTitle={pageInfo.getTabName()}>
+			<TableProvider
+				title={pageInfo.getTitle()}
+				columns={columns}
+				data={data ?? []}
+				isLoading={isLoading}
+				handleCreate={handleCreate}
+				handleUpdate={handleUpdate}
+				handleDelete={handleDelete}
+				handleRefetch={refetch}
+			>
+				{renderSuspenseModals([
+					<DeleteModal
+						{...{
+							deleteItem,
+							setDeleteItem,
+							url,
+							deleteData,
+						}}
+					/>,
+				])}
+			</TableProvider>
+		</PageProvider>
+	);
+};
+
+export default Requisition;

--- a/src/pages/procurement/requisition/useGenerateFieldDefs.tsx
+++ b/src/pages/procurement/requisition/useGenerateFieldDefs.tsx
@@ -1,0 +1,58 @@
+import { UseFormWatch } from 'react-hook-form';
+
+import FieldActionButton from '@/components/buttons/field-action';
+import { IFormSelectOption } from '@/components/core/form/types';
+import { FieldDef } from '@core/form/form-dynamic-fields/types';
+
+import { useOtherItem } from '@/lib/common-queries/other';
+
+import { IRequisition } from './config/schema';
+
+interface IGenerateFieldDefsProps {
+	data: IRequisition;
+	copy: (index: number) => void;
+	remove: (index: number) => void;
+	watch?: UseFormWatch<IRequisition>; // TODO: Update Schema Type
+	isUpdate: boolean;
+}
+
+const useGenerateFieldDefs = ({ data, copy, remove }: IGenerateFieldDefsProps): FieldDef[] => {
+	const { data: itemList } = useOtherItem<IFormSelectOption[]>();
+
+	return [
+		{
+			header: 'Item',
+			accessorKey: 'item_uuid',
+			type: 'select',
+			placeholder: 'Select Item',
+			options: itemList || [],
+			unique: true,
+			excludeOptions: data.item_requisition.map((item) => item.item_uuid) || [],
+		},
+		{
+			header: 'Request Quantity',
+			accessorKey: 'req_quantity',
+			type: 'number',
+		},
+		{
+			header: 'Provided Quantity',
+			accessorKey: 'provided_quantity',
+			type: 'number',
+		},
+		{
+			header: 'Remarks',
+			accessorKey: 'remarks',
+			type: 'textarea',
+		},
+		{
+			header: 'Actions',
+			accessorKey: 'actions',
+			type: 'custom',
+			component: (index: number) => {
+				return <FieldActionButton handleCopy={copy} handleRemove={remove} index={index} />;
+			},
+		},
+	];
+};
+
+export default useGenerateFieldDefs;

--- a/src/pages/procurement/requisition/utils.ts
+++ b/src/pages/procurement/requisition/utils.ts
@@ -1,0 +1,172 @@
+export const departments = [
+	{
+		label: 'Chairman Bot',
+		value: 'chairman_bot',
+	},
+	{
+		label: 'Vice-Chancellor',
+		value: 'vice_chancellor',
+	},
+	{
+		label: 'Treasure',
+		value: 'treasurer',
+	},
+	{
+		label: 'PNI',
+		value: 'pni',
+	},
+	{
+		label: 'PND',
+		value: 'pnd',
+	},
+	{
+		label: 'Civil Engineering',
+		value: 'civil_engineering',
+	},
+	{
+		label: 'Admission Office',
+		value: 'admission_office',
+	},
+	{
+		label: 'Controller Office',
+		value: 'controller_office',
+	},
+	{
+		label: 'Civil Engineering',
+		value: 'civil_engineering',
+	},
+	{
+		label: 'Exam C-01',
+		value: 'exam_c_01',
+	},
+	{
+		label: 'Exam C-02',
+		value: 'exam_c_02',
+	},
+
+	{
+		label: 'Account C-01',
+		value: 'account_c_01',
+	},
+	{
+		label: 'Account C-02',
+		value: 'account_c_02',
+	},
+	{
+		label: 'CSE',
+		value: 'cse',
+	},
+	{
+		label: 'Registrar(HOD)',
+		value: 'registrar(hod)',
+	},
+	{
+		label: 'Additional Registrar',
+		value: 'additional_registrar',
+	},
+	{
+		label: 'Additional Registrar C-01',
+		value: 'additional_registrar_c_01',
+	},
+	{
+		label: 'Additional Registrar C-02',
+		value: 'additional_registrar_c_02',
+	},
+	{
+		label: 'English',
+		value: 'english',
+	},
+	{
+		label: 'Business Administration',
+		value: 'businessadministration',
+	},
+
+	{
+		label: 'Library',
+		value: 'library',
+	},
+	{
+		label: 'IPE & IQAC',
+		value: 'ipe&_iqac',
+	},
+	{
+		label: 'Textile Engineering',
+		value: 'textile_engineering',
+	},
+	{
+		label: 'Proctor Office',
+		value: 'proctor_office',
+	},
+	{
+		label: 'EEE',
+		value: 'eee',
+	},
+	{
+		label: 'FDE',
+		value: 'fde',
+	},
+	{
+		label: 'Medical Centre',
+		value: 'medical_centre',
+	},
+	{
+		label: 'Economics',
+		value: 'economics',
+	},
+	{
+		label: 'MDGS',
+		value: 'mdgs',
+	},
+	{
+		label: 'THM',
+		value: 'thm',
+	},
+	{
+		label: 'Mathematics',
+		value: 'mathematics',
+	},
+	{
+		label: 'PCU',
+		value: 'pcu',
+	},
+	{
+		label: 'Program Coordination Manager',
+		value: 'program_coordination_manager',
+	},
+	{
+		label: 'Program Coordination Assistant Manager',
+		value: 'program_coordination_asst_manager',
+	},
+	{
+		label: 'Senior Program Coordination Incharge',
+		value: 'sr_program_coordination_incharge',
+	},
+	{
+		label: 'Physics',
+		value: 'physics',
+	},
+	{
+		label: 'Chemistry',
+		value: 'chemistry',
+	},
+	{
+		label: 'Security Director',
+		value: 'security_director',
+	},
+	{
+		label: 'Logistics',
+		value: 'logistics',
+	},
+	{
+		label: 'Reception Gate',
+		value: 'reception_gate',
+	},
+	{
+		label: 'ICT',
+		value: 'ict',
+	},
+	{
+		label: 'Law',
+		value: 'law',
+	},
+];

--- a/src/routes/private/portfollo.tsx
+++ b/src/routes/private/portfollo.tsx
@@ -34,6 +34,7 @@ const FinancialInformation = lazy(() => import('@/pages/portfolio/admission/fina
 const Admission = lazy(() => import('@/pages/portfolio/admission/online-form'));
 const AdmissionDetails = lazy(() => import('@/pages/portfolio/admission/online-form/details'));
 const AdmissionEntry = lazy(() => import('@/pages/portfolio/admission/online-form/add-or-update'));
+const Feature = lazy(() => import('@/pages/portfolio/feature/index'));
 
 const portfolioRoutes: IRoute[] = [
 	{
@@ -72,6 +73,13 @@ const portfolioRoutes: IRoute[] = [
 				path: '/portfolio/offers',
 				element: <Offers />,
 				page_name: 'portfolio__offers',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
+			{
+				name: 'Feature',
+				path: '/portfolio/feature',
+				element: <Feature />,
+				page_name: 'portfolio__feature',
 				actions: ['create', 'read', 'update', 'delete'],
 			},
 			{

--- a/src/routes/private/procurement.tsx
+++ b/src/routes/private/procurement.tsx
@@ -124,13 +124,6 @@ const procurementRoutes: IRoute[] = [
 				actions: ['create', 'read', 'update', 'delete'],
 			},
 			{
-				name: 'Internal Cost Center',
-				path: '/procurement/internal-cost-center',
-				element: <InternalCostCenter />,
-				page_name: 'procurement__internal_cost_center',
-				actions: ['create', 'read', 'update', 'delete'],
-			},
-			{
 				name: 'Requisition',
 				path: '/procurement/requisition',
 				element: <Requisition />,
@@ -157,6 +150,13 @@ const procurementRoutes: IRoute[] = [
 			{
 				name: 'Library',
 				children: [
+					{
+						name: 'Internal Cost Center',
+						path: '/procurement/internal-cost-center',
+						element: <InternalCostCenter />,
+						page_name: 'procurement__internal_cost_center',
+						actions: ['create', 'read', 'update', 'delete'],
+					},
 					{
 						name: 'Purchase Cost Center',
 						path: '/procurement/purchase-cost-center',

--- a/src/routes/private/procurement.tsx
+++ b/src/routes/private/procurement.tsx
@@ -15,6 +15,9 @@ const Capital = lazy(() => import('@/pages/procurement/capital'));
 const CapitalEntry = lazy(() => import('@/pages/procurement/capital/entry'));
 const Service = lazy(() => import('@/pages/procurement/service'));
 const ServiceEntry = lazy(() => import('@/pages/procurement/service/entry'));
+const InternalCostCenter = lazy(() => import('@/pages/procurement/internal-cost-center'));
+const Requisition = lazy(() => import('@/pages/procurement/requisition'));
+const RequisitionEntry = lazy(() => import('@/pages/procurement/requisition/entry'));
 
 const procurementRoutes: IRoute[] = [
 	{
@@ -112,6 +115,7 @@ const procurementRoutes: IRoute[] = [
 				page_name: 'procurement__item_update',
 				actions: ['create', 'read', 'update', 'delete'],
 			},
+
 			{
 				name: 'Form',
 				path: '/procurement/form',
@@ -119,6 +123,37 @@ const procurementRoutes: IRoute[] = [
 				page_name: 'procurement__form',
 				actions: ['create', 'read', 'update', 'delete'],
 			},
+			{
+				name: 'Internal Cost Center',
+				path: '/procurement/internal-cost-center',
+				element: <InternalCostCenter />,
+				page_name: 'procurement__internal_cost_center',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
+			{
+				name: 'Requisition',
+				path: '/procurement/requisition',
+				element: <Requisition />,
+				page_name: 'procurement__requisition',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
+			{
+				name: 'Requisition Entry',
+				path: '/procurement/requisition/create',
+				element: <RequisitionEntry />,
+				hidden: true,
+				page_name: 'procurement__requisition_entry',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
+			{
+				name: 'Requisition Update',
+				path: '/procurement/requisition/:uuid/update',
+				element: <RequisitionEntry />,
+				hidden: true,
+				page_name: 'procurement__requisition_update',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
+
 			{
 				name: 'Library',
 				children: [


### PR DESCRIPTION
Introduce feature management with CRUD operations in the Portfolio section and add requisition and internal cost center management in the Procurement section. Refactor the schema by removing unnecessary fields and duplicate definitions.