### PR TITLE
Fix teacher selection and update related components

### DIFF
--- a/src/pages/portfolio/_config/schema/index.ts
+++ b/src/pages/portfolio/_config/schema/index.ts
@@ -145,7 +145,7 @@ export const PORTFOLIO_DEPARTMENT_SCHEMA = z.object({
 				teacher_email: STRING_REQUIRED,
 				teacher_phone: STRING_NULLABLE,
 				teacher_designation: STRING_REQUIRED,
-				teacher_uuid: STRING_REQUIRED,
+				teachers_uuid: STRING_REQUIRED,
 				education: STRING_REQUIRED,
 				publication: STRING_REQUIRED,
 				journal: STRING_REQUIRED,

--- a/src/pages/portfolio/_config/types/index.tsx
+++ b/src/pages/portfolio/_config/types/index.tsx
@@ -54,5 +54,6 @@ export interface IOffersAddOrUpdateProps extends IDefaultImageAddOrUpdateProps {
 export interface IDepartmentTeachersAddOrUpdateProps extends IDefaultAddOrUpdateProps {
 	updatedData?: IDepartmentTeachersTableData | null;
 	isUpdate?: boolean;
+	excludedOption?: any;
 	onSubmit: (data: any) => void;
 }

--- a/src/pages/portfolio/department-teacher/add-or-update/card/add-or-update.tsx
+++ b/src/pages/portfolio/department-teacher/add-or-update/card/add-or-update.tsx
@@ -72,6 +72,7 @@ const AddOrUpdate: React.FC<IDepartmentTeachersAddOrUpdateProps> = ({
 						<CoreForm.ReactSelect
 							label='Teacher'
 							placeholder='Select Teacher'
+							isDisabled={isUpdate}
 							options={teachers!}
 							{...props}
 						/>

--- a/src/pages/portfolio/department-teacher/add-or-update/card/add-or-update.tsx
+++ b/src/pages/portfolio/department-teacher/add-or-update/card/add-or-update.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { te } from 'date-fns/locale';
 import useRHF from '@/hooks/useRHF';
 
 import { IFormSelectOption } from '@/components/core/form/types';
@@ -19,9 +20,11 @@ const AddOrUpdate: React.FC<IDepartmentTeachersAddOrUpdateProps> = ({
 	onSubmit,
 	updatedData,
 	setUpdatedData,
+	excludedOption,
 }) => {
 	const { data: teachers } = useOtherTeachers<IFormSelectOption[]>();
 	const { invalidateQuery: invalidateTeachers } = useDepartmentsTeachers();
+	console.log(excludedOption);
 
 	const form = useRHF(PORTFOLIO_DEPARTMENT_TEACHER_SCHEMA, PORTFOLIO_DEPARTMENT_TEACHER_NULL);
 
@@ -73,7 +76,11 @@ const AddOrUpdate: React.FC<IDepartmentTeachersAddOrUpdateProps> = ({
 							label='Teacher'
 							placeholder='Select Teacher'
 							isDisabled={isUpdate}
-							options={teachers!}
+							options={
+								isUpdate
+									? (teachers ?? [])
+									: (teachers?.filter((teacher) => !excludedOption?.includes(teacher.value)) ?? [])
+							}
 							{...props}
 						/>
 					)}

--- a/src/pages/portfolio/department-teacher/add-or-update/index.tsx
+++ b/src/pages/portfolio/department-teacher/add-or-update/index.tsx
@@ -192,7 +192,6 @@ const AddOrUpdate = () => {
 		setIsUpdateModal(false);
 		setUpdatedData(null);
 		setFormKey((prev) => prev + 1); // force remount
-		console.log('handleCreate', updatedData, form.getValues());
 		setIsOpenAddModal(true);
 	};
 
@@ -423,6 +422,7 @@ const AddOrUpdate = () => {
 						setUpdatedData,
 						postData,
 						updateData,
+						excludedOption: cards?.map((c) => c.teachers_uuid),
 					}}
 				/>
 				,

--- a/src/pages/portfolio/department-teacher/add-or-update/types.ts
+++ b/src/pages/portfolio/department-teacher/add-or-update/types.ts
@@ -64,7 +64,7 @@ export interface ICard {
 	teacher_email: string;
 	teacher_phone: string | null;
 	teacher_designation: string;
-	teacher_uuid: string;
+	teachers_uuid: string;
 	education: string;
 	publication: string;
 	journal: string;

--- a/src/pages/portfolio/teacher/add-or-update.tsx
+++ b/src/pages/portfolio/teacher/add-or-update.tsx
@@ -15,7 +15,7 @@ import nanoid from '@/lib/nanoid';
 import { getDateTime } from '@/utils';
 
 import { ITeacherTableData } from '../_config/columns/columns.type';
-import { useTeachersByUUID } from '../_config/query';
+import { useTeachers, useTeachersByUUID } from '../_config/query';
 import { ITeacher, TEACHER_NULL, TEACHER_SCHEMA } from '../_config/schema';
 
 interface IAddOrUpdateProps {
@@ -63,6 +63,7 @@ const AddOrUpdate: React.FC<IAddOrUpdateProps> = ({
 	const { data } = useTeachersByUUID(updatedData?.uuid as string);
 	const query = isUpdate ? `?uuid=${updatedData?.uuid}` : `is_teacher=false`;
 	const { data: users } = useOtherUserQuery<IFormSelectOption[]>(query);
+	const { invalidateQuery: invalidateTeachers } = useTeachers<ITeacherTableData[]>();
 
 	const form = useRHF(TEACHER_SCHEMA, TEACHER_NULL);
 
@@ -70,6 +71,7 @@ const AddOrUpdate: React.FC<IAddOrUpdateProps> = ({
 		setUpdatedData?.(null);
 		form.reset(TEACHER_NULL);
 		setOpen((prev) => !prev);
+		invalidateTeachers();
 	};
 
 	// Reset form values when data is updated


### PR DESCRIPTION
Disable teacher selection during updates and rename `teacher_uuid` to `teachers_uuid` across relevant components. Import the `useTeachers` hook to invalidate the teachers query upon closing the update modal.