### PR TITLE
Add bill, procure store, and requisition details pages

### DIFF
--- a/src/components/core/data-table/entry.tsx
+++ b/src/components/core/data-table/entry.tsx
@@ -8,6 +8,7 @@ const DataTableEntry = <TData, TValue>({
 	data,
 	toolbarOptions,
 	defaultVisibleColumns,
+	children,
 }: IDataTableEntryProps<TData, TValue>) => {
 	return (
 		<TableProvider
@@ -18,7 +19,9 @@ const DataTableEntry = <TData, TValue>({
 			toolbarOptions={toolbarOptions}
 			defaultVisibleColumns={defaultVisibleColumns}
 			isEntry
-		/>
+		>
+			{children}
+		</TableProvider>
 	);
 };
 

--- a/src/components/core/data-table/index.tsx
+++ b/src/components/core/data-table/index.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { flexRender } from '@tanstack/react-table';
 import useTable from '@/hooks/useTable';
 
@@ -11,7 +12,7 @@ import TableSkeleton from './_components/skeleton';
 import { TableToolbar } from './_components/toolbar';
 import { getCommonPinningStyles } from './_helpers/getCommonPinningStyle';
 
-function DataTable() {
+function DataTable({ children }: { children: ReactNode }) {
 	const { table, isLoading, isEntry } = useTable();
 
 	return (
@@ -83,6 +84,7 @@ function DataTable() {
 								</TableCell>
 							</TableRow>
 						)}
+						{children}
 					</TableBody>
 				</TableComponent>
 

--- a/src/components/core/data-table/types.ts
+++ b/src/components/core/data-table/types.ts
@@ -32,6 +32,7 @@ export interface IDataTableEntryProps<TData, TValue> {
 	data: TData[];
 	toolbarOptions?: 'none' | IToolbarOptions[];
 	defaultVisibleColumns?: any;
+	children?: React.ReactNode;
 }
 
 interface TDefaultColumn<TData, TValue> {

--- a/src/context/TableContext.tsx
+++ b/src/context/TableContext.tsx
@@ -261,8 +261,7 @@ function TableProvider<TData, TValue>({
 
 	return (
 		<TableContext.Provider value={value}>
-			<DataTable />
-			{children}
+			<DataTable children={children} />
 		</TableContext.Provider>
 	);
 }

--- a/src/pages/procurement/bill/add-or-update/index.tsx
+++ b/src/pages/procurement/bill/add-or-update/index.tsx
@@ -1,11 +1,9 @@
-import { it } from 'node:test';
 import { lazy, Suspense, use, useCallback, useEffect, useState } from 'react';
 import { useFieldArray } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import useAuth from '@/hooks/useAuth';
 import useRHF from '@/hooks/useRHF';
 
-import DataTableEntry from '@/components/core/data-table/entry';
 import { ShowLocalToast } from '@/components/others/toast';
 import CoreForm from '@core/form';
 

--- a/src/pages/procurement/bill/config/columns/columns.type.ts
+++ b/src/pages/procurement/bill/config/columns/columns.type.ts
@@ -1,20 +1,32 @@
-// * bill
-export type IBillTableData = {
-	bill_id: string;
-	uuid: string;
-	vendor_uuid: string;
-	bank_uuid: string;
-	item_work_order_uuid: string[];
-	bill_payments: IBillPaymentTableData[];
-	created_by_name: string;
-	created_at: string;
-	updated_at: string;
-};
-
 // * bill payment
 export type IBillPaymentTableData = {
 	uuid: string;
 	bill_uuid: string;
 	type: 'partial' | 'full';
 	amount: number;
+};
+
+//* Item Work Order
+export type IItemWorkOrderTableData = {
+	item_work_order_id: string;
+	total_amount: number;
+};
+
+// * bill
+export type IBillTableData = {
+	bill_id: string;
+	uuid: string;
+	vendor_uuid: string;
+	vendor_name: string;
+	bank_uuid: string;
+	bank_name: string;
+	item_work_order_uuid: string[];
+	total_bill_amount: number;
+	total_amount: number;
+	item_work_order: IItemWorkOrderTableData[];
+	bill_payment: IBillPaymentTableData[];
+	remarks: string;
+	created_by_name: string;
+	created_at: string;
+	updated_at: string;
 };

--- a/src/pages/procurement/bill/config/columns/columns.type.ts
+++ b/src/pages/procurement/bill/config/columns/columns.type.ts
@@ -14,6 +14,7 @@ export type IItemWorkOrderTableData = {
 
 // * bill
 export type IBillTableData = {
+	is_completed: boolean;
 	bill_id: string;
 	uuid: string;
 	vendor_uuid: string;

--- a/src/pages/procurement/bill/config/columns/index.tsx
+++ b/src/pages/procurement/bill/config/columns/index.tsx
@@ -1,13 +1,20 @@
 import { ColumnDef } from '@tanstack/react-table';
 
-import { IBillTableData } from './columns.type';
+import { CustomLink } from '@/components/others/link';
+import DateTime from '@/components/ui/date-time';
 
-// * Capital
+import { IBillPaymentTableData, IBillTableData, IItemWorkOrderTableData } from './columns.type';
+
+// * Bill
 export const billColumns = (): ColumnDef<IBillTableData>[] => [
 	{
 		accessorKey: 'bill_id',
 		header: 'ID',
 		enableColumnFilter: true,
+		cell: (info) => (
+			<CustomLink label={info.getValue() as string} url={`/procurement/bill/${info.row.original.uuid}/details`} />
+		),
+		size: 180,
 	},
 	{
 		accessorKey: 'vendor_name',
@@ -18,5 +25,68 @@ export const billColumns = (): ColumnDef<IBillTableData>[] => [
 		accessorKey: 'bank_name',
 		header: 'Bank',
 		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'total_amount',
+		header: 'Total Bill',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'total_bill_amount',
+		header: 'Total Paid',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'remaining_amount',
+		header: 'Due',
+		enableColumnFilter: true,
+		cell: (info) => {
+			return (
+				<span className='text-red-500'>
+					{info.row.original.total_amount - info.row.original.total_bill_amount}
+				</span>
+			);
+		},
+	},
+];
+
+//* Item Work Order
+export const itemWorkOrderColumns = (): ColumnDef<IItemWorkOrderTableData>[] => [
+	{
+		accessorKey: 'item_work_order_id',
+		header: 'ID',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'total_amount',
+		header: 'Total Amount',
+		enableColumnFilter: true,
+	},
+];
+
+//*Bill Payment
+export const billPaymentColumns = (): ColumnDef<IBillPaymentTableData>[] => [
+	{
+		accessorKey: 'type',
+		header: 'Type',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'amount',
+		header: 'Amount',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'payment_method',
+		header: 'Payment Method',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'payment_date',
+		header: 'Date',
+		enableColumnFilter: true,
+		cell: (info) => {
+			return <DateTime date={info.getValue() as Date} isTime={false} />;
+		},
 	},
 ];

--- a/src/pages/procurement/bill/details/index.tsx
+++ b/src/pages/procurement/bill/details/index.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { IBillTableData } from '../config/columns/columns.type';
+import { useBillByDetails } from '../config/query';
+import Information from './information';
+import Table from './table';
+
+const Index = () => {
+	const { uuid } = useParams();
+	const { data, isLoading } = useBillByDetails(uuid as string);
+
+	useEffect(() => {
+		document.title = 'Bill Details';
+	}, []);
+	if (isLoading) return <div>Loading...</div>;
+	return (
+		<div className='space-y-8'>
+			<Information data={(data || []) as IBillTableData} />
+			<Table data={(data || []) as IBillTableData} isLoading={isLoading} />
+		</div>
+	);
+};
+
+export default Index;

--- a/src/pages/procurement/bill/details/information.tsx
+++ b/src/pages/procurement/bill/details/information.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import StatusButton from '@/components/buttons/status';
 import SectionContainer from '@/components/others/section-container';
 import TableList, { ITableListItems } from '@/components/others/table-list';
 
@@ -10,6 +11,10 @@ import { IBillTableData } from '../config/columns/columns.type'; // TODO: update
 const Information: React.FC<{ data: IBillTableData }> = ({ data }) => {
 	const renderHeaderItems = (): ITableListItems => {
 		return [
+			{
+				label: 'Completed',
+				value: <StatusButton value={data?.is_completed as boolean} />,
+			},
 			{
 				label: 'Vendor',
 				value: data.vendor_name,
@@ -45,8 +50,8 @@ const Information: React.FC<{ data: IBillTableData }> = ({ data }) => {
 		<>
 			<SectionContainer title={'General Information'}>
 				<div className='grid grid-cols-2 gap-2'>
-					<TableList title='Basic Information' items={renderHeaderItems()} />
-					<TableList title='Basic Information' items={renderHeaderItems2()} />
+					<TableList items={renderHeaderItems()} />
+					<TableList items={renderHeaderItems2()} />
 				</div>
 			</SectionContainer>
 		</>

--- a/src/pages/procurement/bill/details/information.tsx
+++ b/src/pages/procurement/bill/details/information.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import SectionContainer from '@/components/others/section-container';
+import TableList, { ITableListItems } from '@/components/others/table-list';
+
+import { formatDateTable } from '@/utils/formatDate';
+
+import { IBillTableData } from '../config/columns/columns.type'; // TODO: update data type
+
+const Information: React.FC<{ data: IBillTableData }> = ({ data }) => {
+	const renderHeaderItems = (): ITableListItems => {
+		return [
+			{
+				label: 'Vendor',
+				value: data.vendor_name,
+			},
+			{
+				label: 'Bank',
+				value: data.bank_name,
+			},
+		];
+	};
+	const renderHeaderItems2 = (): ITableListItems => {
+		return [
+			{
+				label: 'Remarks',
+				value: data.remarks,
+			},
+			{
+				label: 'Created By',
+				value: data.created_by_name,
+			},
+			{
+				label: 'Created At',
+				value: formatDateTable(data.created_at),
+			},
+			{
+				label: 'Updated At',
+				value: formatDateTable(data.updated_at),
+			},
+		];
+	};
+
+	return (
+		<>
+			<SectionContainer title={'General Information'}>
+				<div className='grid grid-cols-2 gap-2'>
+					<TableList title='Basic Information' items={renderHeaderItems()} />
+					<TableList title='Basic Information' items={renderHeaderItems2()} />
+				</div>
+			</SectionContainer>
+		</>
+	);
+};
+
+export default Information;

--- a/src/pages/procurement/bill/details/information.tsx
+++ b/src/pages/procurement/bill/details/information.tsx
@@ -18,14 +18,14 @@ const Information: React.FC<{ data: IBillTableData }> = ({ data }) => {
 				label: 'Bank',
 				value: data.bank_name,
 			},
-		];
-	};
-	const renderHeaderItems2 = (): ITableListItems => {
-		return [
 			{
 				label: 'Remarks',
 				value: data.remarks,
 			},
+		];
+	};
+	const renderHeaderItems2 = (): ITableListItems => {
+		return [
 			{
 				label: 'Created By',
 				value: data.created_by_name,

--- a/src/pages/procurement/bill/details/table.tsx
+++ b/src/pages/procurement/bill/details/table.tsx
@@ -15,7 +15,12 @@ const Table: React.FC<{ data: IBillTableData; isLoading: boolean }> = ({ data, i
 
 	return (
 		<div className='flex flex-col gap-4'>
-			<DataTableEntry title={'Item Work Order'} columns={columnsQ} data={data?.item_work_order ?? []}>
+			<DataTableEntry
+				title={'Item Work Order'}
+				columns={columnsQ}
+				data={data?.item_work_order ?? []}
+				defaultVisibleColumns={{ created_by_name: false, created_at: false, updated_at: false }}
+			>
 				<tr>
 					<td colSpan={1} className='text-right font-semibold'>
 						Grand Total:
@@ -23,7 +28,12 @@ const Table: React.FC<{ data: IBillTableData; isLoading: boolean }> = ({ data, i
 					<td className='px-3 py-2'>{total_item_work_order}</td>
 				</tr>
 			</DataTableEntry>
-			<DataTableEntry title={'Bill Payment'} columns={columnsG} data={data.bill_payment ?? []}>
+			<DataTableEntry
+				title={'Bill Payment'}
+				columns={columnsG}
+				data={data.bill_payment ?? []}
+				defaultVisibleColumns={{ created_by_name: false, created_at: false, updated_at: false }}
+			>
 				<tr>
 					<td colSpan={1} className='text-right font-semibold'>
 						Grand Total:

--- a/src/pages/procurement/bill/details/table.tsx
+++ b/src/pages/procurement/bill/details/table.tsx
@@ -1,0 +1,38 @@
+import { TableProvider } from '@/context';
+
+import DataTable from '@/components/core/data-table';
+import DataTableEntry from '@/components/core/data-table/entry';
+
+import { billPaymentColumns, itemWorkOrderColumns } from '../config/columns';
+import { IBillTableData } from '../config/columns/columns.type';
+
+const Table: React.FC<{ data: IBillTableData; isLoading: boolean }> = ({ data, isLoading }) => {
+	const columnsQ = itemWorkOrderColumns();
+	const columnsG = billPaymentColumns();
+
+	const total_item_work_order = data?.item_work_order.reduce((acc, item) => acc + item.total_amount, 0);
+	const total_bill_payment = data?.bill_payment.reduce((acc, item) => acc + item.amount, 0);
+
+	return (
+		<div className='flex flex-col gap-4'>
+			<DataTableEntry title={'Item Work Order'} columns={columnsQ} data={data?.item_work_order ?? []}>
+				<tr>
+					<td colSpan={1} className='text-right font-semibold'>
+						Grand Total:
+					</td>
+					<td className='px-3 py-2'>{total_item_work_order}</td>
+				</tr>
+			</DataTableEntry>
+			<DataTableEntry title={'Bill Payment'} columns={columnsG} data={data.bill_payment ?? []}>
+				<tr>
+					<td colSpan={1} className='text-right font-semibold'>
+						Grand Total:
+					</td>
+					<td className='px-3 py-2'>{total_bill_payment}</td>
+				</tr>
+			</DataTableEntry>
+		</div>
+	);
+};
+
+export default Table;

--- a/src/pages/procurement/item-request/index.tsx
+++ b/src/pages/procurement/item-request/index.tsx
@@ -101,7 +101,7 @@ const Vendor = () => {
 						{...{
 							deleteItem,
 							setDeleteItem,
-							url,
+							url: `/procure/item-work-order-entry`,
 							deleteData,
 						}}
 					/>,

--- a/src/pages/procurement/procure(store)/config/columns/columns.type.ts
+++ b/src/pages/procurement/procure(store)/config/columns/columns.type.ts
@@ -1,30 +1,33 @@
+// * Items
+export type IItemsWorkOrderEntryTableData = {
+	uuid: string;
+	item_work_order_uuid: string;
+	request_quantity: number;
+	provided_quantity: number;
+	unit_price: number;
+};
 // * capital
+
 export type IProcureStoreTableData = {
 	uuid: string;
 	vendor_name: string;
+	bill_id: string;
+	bank_name: string;
 	remarks: string;
 	bill_uuid: string;
 	vendor_uuid: string;
 	total_amount: number;
 
 	done: boolean;
+	done_date: string;
 	is_delivery_statement: boolean;
 
 	work_order_remarks: string;
 	delivery_statement_remarks: string;
 	delivery_statement_date: string;
-	item_work_order_entry: IItemsWorkOrderTableData[];
+	item_work_order_entry: IItemsWorkOrderEntryTableData[];
 
 	created_by_name: string;
 	created_at: string;
 	updated_at: string;
-};
-
-// * Items
-export type IItemsWorkOrderTableData = {
-	uuid: string;
-	item_work_order_uuid: string;
-	request_quantity: number;
-	provided_quantity: number;
-	unit_price: number;
 };

--- a/src/pages/procurement/procure(store)/config/columns/index.tsx
+++ b/src/pages/procurement/procure(store)/config/columns/index.tsx
@@ -1,23 +1,26 @@
-import { ColumnDef, Row } from '@tanstack/react-table';
+import { ColumnDef } from '@tanstack/react-table';
 
 import StatusButton from '@/components/buttons/status';
 import FilePreview from '@/components/others/file-preview';
-import { Badge } from '@/components/ui/badge';
+import { CustomLink } from '@/components/others/link';
 import DateTime from '@/components/ui/date-time';
-import { FormField } from '@/components/ui/form';
-import CoreForm from '@core/form';
 
-import { cn } from '@/lib/utils';
+import { IItemsWorkOrderEntryTableData, IProcureStoreTableData } from './columns.type';
 
-import { IProcureStoreTableData } from './columns.type';
-
-// * Capital
+// * Procure Store
 export const itemWorkOrderColumns = () // handleDetails: (row: Row<IProcureStoreTableData>) => void
 : ColumnDef<IProcureStoreTableData>[] => [
 	{
 		accessorKey: 'item_work_order_id',
 		header: 'ID',
 		enableColumnFilter: true,
+		cell: (info) => (
+			<CustomLink
+				label={info.getValue() as string}
+				url={`/procurement/procure-store/${info.row.original.uuid}/details`}
+			/>
+		),
+		size: 180,
 	},
 	{
 		accessorKey: 'total_amount',
@@ -79,5 +82,34 @@ export const itemWorkOrderColumns = () // handleDetails: (row: Row<IProcureStore
 		header: 'Done Date',
 		enableColumnFilter: true,
 		cell: (info) => <DateTime date={info.getValue() as Date} isTime={false} />,
+	},
+];
+
+export const itemWorkOrderEntry = (): ColumnDef<IItemsWorkOrderEntryTableData>[] => [
+	{
+		accessorKey: 'item_name',
+		header: 'Item',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'request_quantity',
+		header: 'Request Quantity',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'provided_quantity',
+		header: 'Provided Quantity',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'unit_price',
+		header: 'Unit Price',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'total_amount',
+		header: 'Total Amount',
+		enableColumnFilter: true,
+		cell: (info) => <span>{info.row.original.provided_quantity * info.row.original.unit_price}</span>,
 	},
 ];

--- a/src/pages/procurement/procure(store)/config/schema/index.ts
+++ b/src/pages/procurement/procure(store)/config/schema/index.ts
@@ -54,6 +54,13 @@ export const PROCURE_REQUEST_SCHEMA = z
 					path: [`item_work_order_entry.${index}.provided_quantity`],
 				});
 			}
+			if (data?.is_delivery_statement && (item?.unit_price === undefined || item?.unit_price <= 0)) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: 'Unit Price must be greater than 0',
+					path: [`item_work_order_entry.${index}.unit_price`],
+				});
+			}
 		});
 	});
 

--- a/src/pages/procurement/procure(store)/details/index.tsx
+++ b/src/pages/procurement/procure(store)/details/index.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { IProcureStoreTableData } from '../config/columns/columns.type';
+import { useItemWorkOrderByDetails } from '../config/query';
+import Information from './information';
+import Table from './table';
+
+const Index = () => {
+	const { uuid } = useParams();
+	const { data, isLoading } = useItemWorkOrderByDetails<IProcureStoreTableData>(uuid as string);
+
+	useEffect(() => {
+		document.title = 'Procure Store Details';
+	}, []);
+	if (isLoading) return <div>Loading...</div>;
+	return (
+		<div className='space-y-8'>
+			<Information data={(data || []) as IProcureStoreTableData} />
+			<Table data={(data || []) as IProcureStoreTableData} isLoading={isLoading} />
+		</div>
+	);
+};
+
+export default Index;

--- a/src/pages/procurement/procure(store)/details/information.tsx
+++ b/src/pages/procurement/procure(store)/details/information.tsx
@@ -1,0 +1,79 @@
+import { format } from 'path';
+import React from 'react';
+
+import SectionContainer from '@/components/others/section-container';
+import TableList, { ITableListItems } from '@/components/others/table-list';
+import DateTime from '@/components/ui/date-time';
+
+import { formatDateTable } from '@/utils/formatDate';
+
+import { IProcureStoreTableData } from '../config/columns/columns.type'; // TODO: update data type
+
+const Information: React.FC<{ data: IProcureStoreTableData }> = ({ data }) => {
+	const renderHeaderItems = (): ITableListItems => {
+		return [
+			{
+				label: 'Vendor',
+				value: data.vendor_name,
+			},
+			{
+				label: 'Bill ID',
+				value: data.bill_id,
+			},
+			{
+				label: 'Date',
+				value: data.done_date && <DateTime date={new Date(data.done_date)} isTime={false} />,
+			},
+			{
+				label: 'Remarks',
+				value: data.remarks,
+			},
+		];
+	};
+	const renderHeaderItems2 = (): ITableListItems => {
+		return [
+			{
+				label: 'Created By',
+				value: data.created_by_name,
+			},
+			{
+				label: 'Created At',
+				value: formatDateTable(data.created_at),
+			},
+			{
+				label: 'Updated At',
+				value: formatDateTable(data.updated_at),
+			},
+		];
+	};
+	const renderHeaderItems3 = (): ITableListItems => {
+		return [
+			{
+				label: 'Remarks',
+				value: data.delivery_statement_remarks,
+			},
+			{
+				label: 'Date',
+				value: data.delivery_statement_date ? (
+					<DateTime date={new Date(data.delivery_statement_date)} isTime={false} />
+				) : (
+					'-'
+				),
+			},
+		];
+	};
+
+	return (
+		<>
+			<SectionContainer title={'General Information'}>
+				<div className='grid grid-cols-3 gap-2'>
+					<TableList title='Work Order' items={renderHeaderItems()} />
+					<TableList title='Created and Updated Information' items={renderHeaderItems2()} />
+					<TableList title='Delivery Information' items={renderHeaderItems3()} />
+				</div>
+			</SectionContainer>
+		</>
+	);
+};
+
+export default Information;

--- a/src/pages/procurement/procure(store)/details/table.tsx
+++ b/src/pages/procurement/procure(store)/details/table.tsx
@@ -13,7 +13,12 @@ const Table: React.FC<{ data: IProcureStoreTableData; isLoading: boolean }> = ({
 
 	return (
 		<div className='flex flex-col gap-4'>
-			<DataTableEntry title={'Item Work Order Entry'} columns={columnsQ} data={data?.item_work_order_entry ?? []}>
+			<DataTableEntry
+				title={'Item Work Order Entry'}
+				columns={columnsQ}
+				data={data?.item_work_order_entry ?? []}
+				defaultVisibleColumns={{ created_by_name: false, created_at: false, updated_at: false }}
+			>
 				<tr>
 					<td colSpan={4} className='text-right font-semibold'>
 						Grand Total:

--- a/src/pages/procurement/procure(store)/details/table.tsx
+++ b/src/pages/procurement/procure(store)/details/table.tsx
@@ -1,0 +1,28 @@
+import DataTableEntry from '@/components/core/data-table/entry';
+
+import { itemWorkOrderEntry } from '../config/columns';
+import { IProcureStoreTableData } from '../config/columns/columns.type';
+
+const Table: React.FC<{ data: IProcureStoreTableData; isLoading: boolean }> = ({ data, isLoading }) => {
+	const columnsQ = itemWorkOrderEntry();
+
+	const total_item_work_order = data?.item_work_order_entry.reduce(
+		(acc, item) => acc + item.provided_quantity * item.unit_price,
+		0
+	);
+
+	return (
+		<div className='flex flex-col gap-4'>
+			<DataTableEntry title={'Item Work Order Entry'} columns={columnsQ} data={data?.item_work_order_entry ?? []}>
+				<tr>
+					<td colSpan={4} className='text-right font-semibold'>
+						Grand Total:
+					</td>
+					<td className='px-3 py-2'>{total_item_work_order}</td>
+				</tr>
+			</DataTableEntry>
+		</div>
+	);
+};
+
+export default Table;

--- a/src/pages/procurement/procure/entry.tsx
+++ b/src/pages/procurement/procure/entry.tsx
@@ -1,9 +1,7 @@
-import { watch } from 'fs';
 import { Suspense, useEffect, useState } from 'react';
 import { useFieldArray } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
-import { array } from 'zod';
 import useAuth from '@/hooks/useAuth';
 import useRHF from '@/hooks/useRHF';
 

--- a/src/pages/procurement/requisition/config/columns/columns.type.ts
+++ b/src/pages/procurement/requisition/config/columns/columns.type.ts
@@ -6,6 +6,7 @@ export type IItemRequisitionTableData = {
 	requisition_name: string;
 	req_quantity: number;
 	provided_quantity: number;
+	prev_provided_quantity: number;
 	created_by_name: string;
 	prev_provided_date: string;
 };
@@ -21,6 +22,7 @@ export type IRequisitionTableData = {
 	received_date: string;
 	created_at: string;
 	created_by_name: string;
+	updated_at: string;
 	designation: string;
 
 	department:

--- a/src/pages/procurement/requisition/config/columns/index.tsx
+++ b/src/pages/procurement/requisition/config/columns/index.tsx
@@ -3,10 +3,11 @@ import { ColumnDef, Row } from '@tanstack/react-table';
 import Transfer from '@/components/buttons/transfer';
 import TableCellAction from '@/components/core/data-table/_components/cell-action';
 import HoverCardWrapper from '@/components/others/hover-card-wrapper';
+import { CustomLink } from '@/components/others/link';
 import DateTime from '@/components/ui/date-time';
 import { Switch } from '@/components/ui/switch';
 
-import { IRequisitionTableData } from './columns.type';
+import { IItemRequisitionTableData, IRequisitionTableData } from './columns.type';
 
 // * Requisition Table Columns
 export const requisitionColumns = (
@@ -27,10 +28,12 @@ export const requisitionColumns = (
 		header: 'ID',
 		enableColumnFilter: true,
 		cell: (info) => (
-			<button className='underline' onClick={() => handlePdf(info.row)}>
-				{info.getValue() as string}
-			</button>
+			<CustomLink
+				label={info.getValue() as string}
+				url={`/procurement/requisition/${info.row.original.uuid}/details`}
+			/>
 		),
+		size: 180,
 	},
 	{
 		accessorKey: 'is_store_received',
@@ -156,6 +159,47 @@ export const requisitionColumns = (
 		meta: {
 			hidden: !updateAccess && !deleteAccess,
 			disableFullFilter: true,
+		},
+	},
+];
+
+export const itemRequisition = (): ColumnDef<IItemRequisitionTableData>[] => [
+	{
+		accessorKey: 'item_name',
+		header: 'Item',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'req_quantity',
+		header: 'Req. Qty',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'provided_quantity',
+		header: 'Prov. Qty',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'provided_quantity',
+		header: 'Prov. Qty',
+		enableColumnFilter: true,
+	},
+	{
+		accessorKey: 'prev_provided_quantity',
+		header: 'Prev.Prov. Qty',
+		enableColumnFilter: true,
+		cell: (info) => {
+			return (
+				<div>
+					<span>{info.row.original.prev_provided_quantity}</span>
+					<DateTime
+						date={
+							info.row.original.prev_provided_date ? new Date(info.row.original.prev_provided_date) : null
+						}
+						isTime={false}
+					/>
+				</div>
+			);
 		},
 	},
 ];

--- a/src/pages/procurement/requisition/details/index.tsx
+++ b/src/pages/procurement/requisition/details/index.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import OrderSheetPdf from '../../../../components/pdf/item-requstion';
+import { IRequisitionTableData } from '../config/columns/columns.type';
+import { useRequisitionAndItemByUUID, useRequisitionAndItemForPDF } from '../config/query';
+import Information from './information';
+import Table from './table';
+
+const Index = () => {
+	const { uuid } = useParams();
+	const { data, isLoading } = useRequisitionAndItemByUUID<IRequisitionTableData>(uuid as string);
+
+	useEffect(() => {
+		document.title = 'Requisition Details';
+	}, []);
+	const [data2, setData] = useState('');
+
+	useEffect(() => {
+		if (data) {
+			OrderSheetPdf(data)?.getDataUrl((dataUrl) => {
+				setData(dataUrl);
+			});
+		}
+	}, [data]);
+	if (isLoading) return <div>Loading...</div>;
+	return (
+		<div className='space-y-8'>
+			<iframe src={data2} className='h-[40rem] w-full rounded-md border-none' />
+			<Information data={(data || []) as IRequisitionTableData} />
+			<Table data={(data || []) as IRequisitionTableData} isLoading={isLoading} />
+		</div>
+	);
+};
+
+export default Index;

--- a/src/pages/procurement/requisition/details/information.tsx
+++ b/src/pages/procurement/requisition/details/information.tsx
@@ -8,27 +8,38 @@ import DateTime from '@/components/ui/date-time';
 
 import { formatDateTable } from '@/utils/formatDate';
 
-import { IProcureStoreTableData } from '../config/columns/columns.type'; // TODO: update data type
+import { IRequisitionTableData } from '../config/columns/columns.type'; // TODO: update data type
 
-const Information: React.FC<{ data: IProcureStoreTableData }> = ({ data }) => {
+const Information: React.FC<{ data: IRequisitionTableData }> = ({ data }) => {
 	const renderHeaderItems = (): ITableListItems => {
 		return [
 			{
-				label: 'Done',
-				value: <StatusButton value={data?.done as boolean} />,
+				label: 'ID',
+				value: data.requisition_id,
 			},
 			{
-				label: 'Vendor',
-				value: data.vendor_name,
+				label: 'Store Received',
+				value: <StatusButton value={data?.is_store_received as boolean} />,
 			},
 			{
-				label: 'Bill ID',
-				value: data.bill_id,
+				label: 'Store Received Date',
+				value: data.store_received_date && (
+					<DateTime date={new Date(data.store_received_date)} isTime={false} />
+				),
 			},
 			{
-				label: 'Date',
-				value: data.done_date && <DateTime date={new Date(data.done_date)} isTime={false} />,
+				label: 'PI Generated Number',
+				value: data.pi_generated_number,
 			},
+			{
+				label: 'Received',
+				value: <StatusButton value={data?.is_received as boolean} />,
+			},
+			{
+				label: 'Received Date',
+				value: data.received_date && <DateTime date={new Date(data.received_date)} isTime={false} />,
+			},
+
 			{
 				label: 'Remarks',
 				value: data.remarks,
@@ -51,34 +62,13 @@ const Information: React.FC<{ data: IProcureStoreTableData }> = ({ data }) => {
 			},
 		];
 	};
-	const renderHeaderItems3 = (): ITableListItems => {
-		return [
-			{
-				label: 'Completed',
-				value: <StatusButton value={data?.is_delivery_statement as boolean} />,
-			},
-			{
-				label: 'Remarks',
-				value: data.delivery_statement_remarks,
-			},
-			{
-				label: 'Date',
-				value: data.delivery_statement_date ? (
-					<DateTime date={new Date(data.delivery_statement_date)} isTime={false} />
-				) : (
-					'-'
-				),
-			},
-		];
-	};
 
 	return (
 		<>
 			<SectionContainer title={'General Information'}>
-				<div className='grid grid-cols-3 gap-2'>
+				<div className='grid grid-cols-2 gap-2'>
 					<TableList title='Work Order' items={renderHeaderItems()} />
 					<TableList title='Created and Updated Information' items={renderHeaderItems2()} />
-					<TableList title='Delivery Information' items={renderHeaderItems3()} />
 				</div>
 			</SectionContainer>
 		</>

--- a/src/pages/procurement/requisition/details/table.tsx
+++ b/src/pages/procurement/requisition/details/table.tsx
@@ -1,0 +1,21 @@
+import DataTableEntry from '@/components/core/data-table/entry';
+
+import { itemRequisition } from '../config/columns';
+import { IRequisitionTableData } from '../config/columns/columns.type';
+
+const Table: React.FC<{ data: IRequisitionTableData; isLoading: boolean }> = ({ data, isLoading }) => {
+	const columnsQ = itemRequisition();
+
+	return (
+		<div className='flex flex-col gap-4'>
+			<DataTableEntry
+				title={'Item Work Order Entry'}
+				columns={columnsQ}
+				data={data?.item_requisition ?? []}
+				defaultVisibleColumns={{ created_by_name: false, created_at: false, updated_at: false }}
+			></DataTableEntry>
+		</div>
+	);
+};
+
+export default Table;

--- a/src/routes/private/procurement.tsx
+++ b/src/routes/private/procurement.tsx
@@ -23,6 +23,7 @@ const ServiceDetails = lazy(() => import('@/pages/procurement/service/details'))
 const InternalCostCenter = lazy(() => import('@/pages/procurement/internal-cost-center'));
 const Requisition = lazy(() => import('@/pages/procurement/requisition'));
 const RequisitionEntry = lazy(() => import('@/pages/procurement/requisition/entry'));
+const RequisitionDetails = lazy(() => import('@/pages/procurement/requisition/details'));
 const RequisitionProvided = lazy(() => import('@/pages/procurement/requisition/provided'));
 const Log = lazy(() => import('@/pages/procurement/log'));
 const ReportItem = lazy(() => import('@/pages/procurement/report/item/index'));
@@ -274,6 +275,14 @@ const procurementRoutes: IRoute[] = [
 					'click_store_received_override',
 					'click_store_received',
 				],
+			},
+			{
+				name: 'Requisition Details',
+				path: '/procurement/requisition/:uuid/details',
+				element: <RequisitionDetails />,
+				hidden: true,
+				page_name: 'procurement__requisition_details',
+				actions: ['create', 'read', 'update', 'delete'],
 			},
 			{
 				name: 'Requisition Entry',

--- a/src/routes/private/procurement.tsx
+++ b/src/routes/private/procurement.tsx
@@ -34,6 +34,7 @@ const ComparativeStatement = lazy(() => import('@/pages/procurement/pdf-make/com
 const SubPurchaseCostCenter = lazy(() => import('@/pages/procurement/sub-purchase-cost-center'));
 const ProcureStore = lazy(() => import('@/pages/procurement/procure(store)'));
 const ProcureStoreEntry = lazy(() => import('@/pages/procurement/procure(store)/entry'));
+const ProcureStoreDetails = lazy(() => import('@/pages/procurement/procure(store)/details'));
 const Bill = lazy(() => import('@/pages/procurement/bill'));
 const BillDetails = lazy(() => import('@/pages/procurement/bill/details'));
 const BillEntry = lazy(() => import('@/pages/procurement/bill/add-or-update'));
@@ -76,6 +77,7 @@ const procurementRoutes: IRoute[] = [
 				path: '/procurement/bill/:uuid/details',
 				element: <BillDetails />,
 				page_name: 'procurement__bill_details',
+				hidden: true,
 				actions: ['create', 'read', 'update', 'delete'],
 			},
 			{
@@ -99,6 +101,30 @@ const procurementRoutes: IRoute[] = [
 				path: '/procurement/procure-store',
 				element: <ProcureStore />,
 				page_name: 'procurement__procure_store',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
+			{
+				name: 'Procure (Store)',
+				path: '/procurement/procure-store/:uuid/details',
+				element: <ProcureStoreDetails />,
+				hidden: true,
+				page_name: 'procurement__procure_store_details',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
+			{
+				name: 'Procure Entry (Store)',
+				path: '/procurement/procure-store/create',
+				element: <ProcureStoreEntry />,
+				hidden: true,
+				page_name: 'procurement__procure_store_entry',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
+			{
+				name: 'Procure Update (Store)',
+				path: '/procurement/procure-store/:uuid/update',
+				element: <ProcureStoreEntry />,
+				hidden: true,
+				page_name: 'procurement__procure_store_update',
 				actions: ['create', 'read', 'update', 'delete'],
 			},
 			{
@@ -309,23 +335,6 @@ const procurementRoutes: IRoute[] = [
 				element: <ComparativeStatement />,
 				hidden: true,
 				page_name: 'procurement__pdf_form_comparative_statement',
-				actions: ['create', 'read', 'update', 'delete'],
-			},
-
-			{
-				name: 'Procure Entry (Store)',
-				path: '/procurement/procure-store/create',
-				element: <ProcureStoreEntry />,
-				hidden: true,
-				page_name: 'procurement__procure_store_entry',
-				actions: ['create', 'read', 'update', 'delete'],
-			},
-			{
-				name: 'Procure Update (Store)',
-				path: '/procurement/procure-store/:uuid/update',
-				element: <ProcureStoreEntry />,
-				hidden: true,
-				page_name: 'procurement__procure_store_update',
 				actions: ['create', 'read', 'update', 'delete'],
 			},
 

--- a/src/routes/private/procurement.tsx
+++ b/src/routes/private/procurement.tsx
@@ -35,6 +35,7 @@ const SubPurchaseCostCenter = lazy(() => import('@/pages/procurement/sub-purchas
 const ProcureStore = lazy(() => import('@/pages/procurement/procure(store)'));
 const ProcureStoreEntry = lazy(() => import('@/pages/procurement/procure(store)/entry'));
 const Bill = lazy(() => import('@/pages/procurement/bill'));
+const BillDetails = lazy(() => import('@/pages/procurement/bill/details'));
 const BillEntry = lazy(() => import('@/pages/procurement/bill/add-or-update'));
 const Bank = lazy(() => import('@/pages/procurement/bank'));
 // const ProcureStoreDetails = lazy(() => import('@/pages/procurement/procure(store)/details'));
@@ -68,6 +69,13 @@ const procurementRoutes: IRoute[] = [
 				path: '/procurement/bill',
 				element: <Bill />,
 				page_name: 'procurement__bill',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
+			{
+				name: 'Bill',
+				path: '/procurement/bill/:uuid/details',
+				element: <BillDetails />,
+				page_name: 'procurement__bill_details',
 				actions: ['create', 'read', 'update', 'delete'],
 			},
 			{

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -3,7 +3,7 @@ import { format } from 'date-fns';
 
 const formatDate = (date: Date) => format(date, 'yyyy-MM-dd HH:mm:ss');
 
-const formatDateTable = (date: Date | string) => format(new Date(date), 'dd/MM/yyyy');
+const formatDateTable = (date: Date | string) => (date ? format(new Date(date), 'dd/MM/yyyy') : null);
 
 const formatQueryDates = ({ start_date, end_date }: IStartEndDateProps) => ({
 	start_date: start_date ? (format(start_date, 'yyyy-MM-dd') as string) : undefined,


### PR DESCRIPTION
Introduce new pages for displaying detailed information about bills, procure stores, and requisitions, along with their respective table components. Update validation for unit prices in procurement forms and adjust URL for item deletion.