### PR TITLE
Fix store type access bug in Items page

### DIFF
--- a/src/pages/procurement/item/index.tsx
+++ b/src/pages/procurement/item/index.tsx
@@ -18,15 +18,19 @@ const Details = lazy(() => import('./details'));
 const DeleteModal = lazy(() => import('@core/modal/delete'));
 
 const getAccess = (pageAccess: string[]) => {
+	const types: string[] = [];
+
 	if (pageAccess.includes('show_maintenance')) {
-		return 'store_type=maintenance';
-	} else if (pageAccess.includes('show_general')) {
-		return 'store_type=general';
-	} else if (pageAccess.includes('show_it_store')) {
-		return 'store_type=it_store';
-	} else {
-		return '';
+		types.push('maintenance');
 	}
+	if (pageAccess.includes('show_general')) {
+		types.push('general');
+	}
+	if (pageAccess.includes('show_it_store')) {
+		types.push('it_store');
+	}
+
+	return types.length > 0 ? `store_type=${types.join(',')}` : '';
 };
 
 const Designation = () => {
@@ -36,6 +40,7 @@ const Designation = () => {
 	const { data, isLoading, url, deleteData, postData, updateData, refetch } = useItem<IItemTableData[]>(
 		getAccess(pageAccess)
 	);
+	console.log(getAccess(pageAccess));
 	const [itemUuid, setItemUuid] = useState<string | null>(null);
 
 	const pageInfo = useMemo(() => new PageInfo('Item', url, 'procurement__item'), [url]);


### PR DESCRIPTION
Resolve an issue with store type access by allowing multiple store types to be returned based on page access permissions. This change enhances the flexibility of access control on the Items page.