### PR TITLE
Update unit_price type in PROCURE_REQUEST_SCHEMA

### DIFF
--- a/src/pages/procurement/procure(store)/config/schema/index.ts
+++ b/src/pages/procurement/procure(store)/config/schema/index.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import {
 	BOOLEAN_REQUIRED,
+	NUMBER_DOUBLE_OPTIONAL,
 	NUMBER_OPTIONAL,
 	NUMBER_REQUIRED,
 	STRING_NULLABLE,
@@ -37,7 +38,7 @@ export const PROCURE_REQUEST_SCHEMA = z
 					message: 'Must be greater than 0',
 				}),
 				provided_quantity: NUMBER_REQUIRED.min(1, 'Provided Quantity must be greater than 0'),
-				unit_price: NUMBER_OPTIONAL,
+				unit_price: NUMBER_DOUBLE_OPTIONAL,
 			})
 		),
 		work_order_remarks: STRING_NULLABLE,


### PR DESCRIPTION
Change the type of unit_price to NUMBER_DOUBLE_OPTIONAL to allow for more precise pricing in the procurement request schema.