### PR TITLE
Add 'Without Item Request' feature and fix bugs

### DIFF
--- a/src/components/core/data-table-ssr/_components/pagination.tsx
+++ b/src/components/core/data-table-ssr/_components/pagination.tsx
@@ -34,7 +34,7 @@ export function TablePagination() {
 									<SelectValue placeholder={searchParams.get('limit') || '10'} />
 								</SelectTrigger>
 								<SelectContent side='top'>
-									{[10, 20, 30, 40, 50].map((pageSize) => (
+									{[10, 20, 50, 100].map((pageSize) => (
 										<SelectItem key={pageSize} value={`${pageSize}`}>
 											{pageSize}
 										</SelectItem>

--- a/src/components/core/data-table/_components/pagination.tsx
+++ b/src/components/core/data-table/_components/pagination.tsx
@@ -31,7 +31,7 @@ export function TablePagination() {
 								<SelectValue placeholder={table.getState().pagination.pageSize} />
 							</SelectTrigger>
 							<SelectContent side='top'>
-								{[10, 20, 30, 40, 50].map((pageSize) => (
+								{[10, 20, 50, 100].map((pageSize) => (
 									<SelectItem key={pageSize} value={`${pageSize}`}>
 										{pageSize}
 									</SelectItem>

--- a/src/pages/procurement/item/config/columns/index.tsx
+++ b/src/pages/procurement/item/config/columns/index.tsx
@@ -87,16 +87,16 @@ export const itemColumns = (
 		enableColumnFilter: true,
 	},
 
-	// {
-	// 	id: 'action_trx',
-	// 	header: 'Item Transfer',
-	// 	cell: (info) => <Transfer onClick={() => handleTrx(info.row)} />,
-	// 	size: 40,
-	// 	meta: {
-	// 		hidden: !actionTrxAccess,
-	// 		disableFullFilter: true,
-	// 	},
-	// },
+	{
+		id: 'action_trx',
+		header: 'Item Transfer',
+		cell: (info) => <Transfer onClick={() => handleTrx(info.row)} />,
+		size: 40,
+		meta: {
+			hidden: !actionTrxAccess,
+			disableFullFilter: true,
+		},
+	},
 ];
 // * vendor
 export const vendorColumns = (): ColumnDef<IItemVendorTableData>[] => [

--- a/src/pages/procurement/log/config/columns/columns.type.ts
+++ b/src/pages/procurement/log/config/columns/columns.type.ts
@@ -14,6 +14,7 @@ export type IITemTransferTableData = {
 export type IItemWorkOrderEntryTableData = {
 	uuid: string;
 	item_work_order_name: string;
+	item_work_order_uuid: string;
 	item_name: string;
 	quantity: number;
 	unit_price: number;

--- a/src/pages/procurement/log/config/columns/index.tsx
+++ b/src/pages/procurement/log/config/columns/index.tsx
@@ -2,6 +2,7 @@ import { ColumnDef } from '@tanstack/react-table';
 
 import StatusButton from '@/components/buttons/status';
 import TableCellAction from '@/components/core/data-table/_components/cell-action';
+import { CustomLink } from '@/components/others/link';
 import DateTime from '@/components/ui/date-time';
 
 import {
@@ -52,6 +53,12 @@ export const itemWorkOrderEntryColumns = (): ColumnDef<IItemWorkOrderEntryTableD
 		accessorKey: 'item_work_order_id',
 		header: 'Item Work Order',
 		enableColumnFilter: true,
+		cell: (info) => (
+			<CustomLink
+				label={info.getValue() as string}
+				url={`/procurement/procure-store/${info.row.original.item_work_order_uuid}/details`}
+			/>
+		),
 	},
 	{
 		accessorKey: 'item_name',

--- a/src/pages/procurement/log/index.tsx
+++ b/src/pages/procurement/log/index.tsx
@@ -12,6 +12,8 @@ const Log = () => {
 		<div>
 			{/* <ItemTransferLog />
 			<hr className='border-secondary-content my-6 border-2 border-dashed' /> */}
+			<ItemTransferLog />
+			<hr className='border-secondary-content my-6 border-2 border-dashed' />
 			<ItemWorkOrderEntry />
 			<hr className='border-secondary-content my-6 border-2 border-dashed' />
 			<ItemRequisition />

--- a/src/pages/procurement/procure(store)/config/columns/index.tsx
+++ b/src/pages/procurement/procure(store)/config/columns/index.tsx
@@ -11,9 +11,16 @@ import { IItemsWorkOrderEntryTableData, IProcureStoreTableData } from './columns
 export const itemWorkOrderColumns = () // handleDetails: (row: Row<IProcureStoreTableData>) => void
 : ColumnDef<IProcureStoreTableData>[] => [
 	{
+		accessorKey: 'done',
+		header: 'Done',
+		enableColumnFilter: false,
+		size: 100,
+		cell: (info) => <StatusButton value={info.getValue() as boolean} />,
+	},
+	{
 		accessorKey: 'item_work_order_id',
 		header: 'ID',
-		enableColumnFilter: true,
+		enableColumnFilter: false,
 		cell: (info) => (
 			<CustomLink
 				label={info.getValue() as string}
@@ -25,98 +32,94 @@ export const itemWorkOrderColumns = () // handleDetails: (row: Row<IProcureStore
 	{
 		accessorKey: 'total_amount',
 		header: 'Total \nAmount',
-		enableColumnFilter: true,
+		enableColumnFilter: false,
 		size: 100,
 	},
-	{
-		accessorKey: 'bill_id',
-		header: 'Bill',
-		enableColumnFilter: true,
-		cell: (info) => (
-			<CustomLink
-				label={info.getValue() as string}
-				url={`/procurement/bill/${info.row.original.bill_uuid}/details`}
-			/>
-		),
-	},
+
 	{
 		accessorKey: 'vendor_name',
 		header: 'Vendor',
-		enableColumnFilter: true,
+		enableColumnFilter: false,
 	},
 	{
 		accessorKey: 'work_order_file',
 		header: 'Work Order \nFile',
-		enableColumnFilter: true,
+		enableColumnFilter: false,
 		cell: (info) => <FilePreview preview={info.getValue() as string} />,
 	},
+	// {
+	// 	accessorKey: 'work_order_remarks',
+	// 	header: 'Work Order \nRemarks',
+	// 	enableColumnFilter: false,
+	// },
 	{
-		accessorKey: 'work_order_remarks',
-		header: 'Work Order \nRemarks',
-		enableColumnFilter: true,
-	},
-	{
-		accessorKey: 'is_delivery_statement',
-		header: 'Delivery \nStatement',
-		enableColumnFilter: true,
+		accessorKey: 'without_item_request',
+		header: 'Without \nRequest',
+		enableColumnFilter: false,
+		size: 100,
 		cell: (info) => <StatusButton value={info.getValue() as boolean} />,
-	},
-	{
-		accessorKey: 'delivery_statement_date',
-		header: 'Delivery \nStatement Date',
-		enableColumnFilter: true,
-		cell: (info) => <DateTime date={info.getValue() as Date} isTime={false} />,
 	},
 	{
 		accessorKey: 'delivery_statement_file',
 		header: 'Delivery \nStatement File',
-		enableColumnFilter: true,
+		enableColumnFilter: false,
 		cell: (info) => <FilePreview preview={info.getValue() as string} />,
 	},
 	{
-		accessorKey: 'delivery_statement_remarks',
-		header: 'Delivery \nStatement Remarks',
-		enableColumnFilter: true,
+		accessorKey: 'is_delivery_statement',
+		header: 'Delivery \nStatement',
+		enableColumnFilter: false,
+		cell: (info) => {
+			const { is_delivery_statement, delivery_statement_date } = info.row.original;
+
+			return (
+				<div className='flex items-center gap-2'>
+					<StatusButton value={is_delivery_statement as boolean} />
+					<DateTime date={new Date(delivery_statement_date)} />
+				</div>
+			);
+		},
 	},
-	{
-		accessorKey: 'done',
-		header: 'Done',
-		enableColumnFilter: true,
-		cell: (info) => <StatusButton value={info.getValue() as boolean} />,
-	},
-	{
-		accessorKey: 'done_date',
-		header: 'Done Date',
-		enableColumnFilter: true,
-		cell: (info) => <DateTime date={info.getValue() as Date} isTime={false} />,
-	},
+
+	// {
+	// 	accessorKey: 'delivery_statement_remarks',
+	// 	header: 'Delivery \nStatement Remarks',
+	// 	enableColumnFilter: false,
+	// },
+
+	// {
+	// 	accessorKey: 'done_date',
+	// 	header: 'Done Date',
+	// 	enableColumnFilter: false,
+	// 	cell: (info) => <DateTime date={info.getValue() as Date} isTime={false} />,
+	// },
 ];
 
 export const itemWorkOrderEntry = (): ColumnDef<IItemsWorkOrderEntryTableData>[] => [
 	{
 		accessorKey: 'item_name',
 		header: 'Item',
-		enableColumnFilter: true,
+		enableColumnFilter: false,
 	},
 	{
 		accessorKey: 'request_quantity',
 		header: 'Request Quantity',
-		enableColumnFilter: true,
+		enableColumnFilter: false,
 	},
 	{
 		accessorKey: 'provided_quantity',
 		header: 'Provided Quantity',
-		enableColumnFilter: true,
+		enableColumnFilter: false,
 	},
 	{
 		accessorKey: 'unit_price',
 		header: 'Unit Price',
-		enableColumnFilter: true,
+		enableColumnFilter: false,
 	},
 	{
 		accessorKey: 'total_amount',
 		header: 'Total Amount',
-		enableColumnFilter: true,
+		enableColumnFilter: false,
 		cell: (info) => <span>{info.row.original.provided_quantity * info.row.original.unit_price}</span>,
 	},
 ];

--- a/src/pages/procurement/procure(store)/config/schema/index.ts
+++ b/src/pages/procurement/procure(store)/config/schema/index.ts
@@ -34,9 +34,10 @@ export const PROCURE_REQUEST_SCHEMA = z
 			z.object({
 				uuid: STRING_OPTIONAL,
 				item_uuid: STRING_OPTIONAL,
-				request_quantity: NUMBER_OPTIONAL.refine((val) => val !== undefined && val > 0, {
-					message: 'Must be greater than 0',
-				}),
+				request_quantity: NUMBER_OPTIONAL,
+				// request_quantity: NUMBER_OPTIONAL.refine((val) => val !== undefined && val > 0, {
+				// 	message: 'Must be greater than 0',
+				// }),
 				provided_quantity: NUMBER_REQUIRED.min(1, 'Provided Quantity must be greater than 0'),
 				unit_price: NUMBER_DOUBLE_OPTIONAL,
 			})
@@ -44,19 +45,21 @@ export const PROCURE_REQUEST_SCHEMA = z
 		work_order_remarks: STRING_NULLABLE,
 		vendor_uuid: STRING_REQUIRED,
 
+		without_item_request: BOOLEAN_REQUIRED.default(false),
 		is_delivery_statement: BOOLEAN_REQUIRED.default(false),
 		delivery_statement_date: STRING_OPTIONAL.nullable(),
 		delivery_statement_remarks: STRING_NULLABLE,
 	})
 	.superRefine((data, ctx) => {
 		data?.item_work_order_entry.forEach((item, index) => {
-			if (item?.request_quantity && item?.request_quantity < item?.provided_quantity) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					message: 'Provided Quantity must be less than or equal to Requested Quantity',
-					path: [`item_work_order_entry.${index}.provided_quantity`],
-				});
-			}
+			// if (item?.request_quantity && 0 < item?.provided_quantity) {
+			// 	ctx.addIssue({
+			// 		code: z.ZodIssueCode.custom,
+			// 		message: 'Provided Quantity must be less than or equal to Requested Quantity',
+			// 		path: [`item_work_order_entry.${index}.provided_quantity`],
+			// 	});
+			// }
+
 			if (data?.is_delivery_statement && (item?.unit_price === undefined || item?.unit_price <= 0)) {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
@@ -80,6 +83,7 @@ export const PROCURE_REQUEST_NULL: Partial<IProcureRequest> = {
 	work_order_remarks: null,
 	vendor_uuid: '',
 
+	without_item_request: false,
 	is_delivery_statement: false,
 	delivery_statement_date: null,
 	delivery_statement_remarks: null,

--- a/src/pages/procurement/procure(store)/entry.tsx
+++ b/src/pages/procurement/procure(store)/entry.tsx
@@ -1,3 +1,4 @@
+import { watch } from 'fs';
 import { Suspense, useEffect, useState } from 'react';
 import { useFieldArray } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -237,6 +238,8 @@ const Entry = () => {
 				});
 		}
 	}
+
+	console.log(form.formState.errors);
 	return (
 		<CoreForm.AddEditWrapper
 			title={isUpdate ? 'Update Procure(Store)' : 'Add Procure(Store)'}
@@ -261,6 +264,7 @@ const Entry = () => {
 								name='done'
 								render={(props) => (
 									<CoreForm.Switch
+										disabled={!form.watch('is_delivery_statement')}
 										labelClassName='text-slate-100'
 										label='Done'
 										onCheckedChange={(e) => {
@@ -360,6 +364,27 @@ const Entry = () => {
 				fieldDefs={fieldDefsItems}
 				fields={itemsFields}
 				handleAdd={data?.is_delivery_statement ? undefined : handleAddItems}
+				extraHeader={
+					<FormField
+						control={form.control}
+						name='without_item_request'
+						render={(props) => (
+							<CoreForm.Switch
+								label='Without Item Request'
+								labelClassName='text-slate-100'
+								disabled={isUpdate}
+								onCheckedChange={(e) => {
+									if (e) {
+										form.getValues('item_work_order_entry').forEach((item: any, index: number) => {
+											form.setValue(`item_work_order_entry.${index}.request_quantity`, 0);
+										});
+									}
+								}}
+								{...props}
+							/>
+						)}
+					/>
+				}
 			>
 				<tr>
 					<td className='border-t text-right font-semibold' colSpan={5}>

--- a/src/pages/procurement/procure(store)/item-request-table.tsx
+++ b/src/pages/procurement/procure(store)/item-request-table.tsx
@@ -43,7 +43,7 @@ const ItemRequestTable = () => {
 
 	return (
 		<TableProvider
-			title={'Item Request Data'}
+			title={'Item Request'}
 			columns={columns}
 			data={data ?? []}
 			isLoading={isLoading}

--- a/src/pages/procurement/procure(store)/item-select-filter.tsx
+++ b/src/pages/procurement/procure(store)/item-select-filter.tsx
@@ -31,7 +31,9 @@ const ItemSelectFilter: React.FC<{ uuid?: string; form: any; index: number; disa
 }) => {
 	const pageAccess = useAccess('procurement__item') as string[];
 	const query = uuid ? `${getAccess(pageAccess)}` : `item_work_order_uuid=null&${getAccess(pageAccess)}`;
-	const { data: itemList } = useOtherRequestedItems<ICustomItemSelectOptions[]>(query);
+	const { data: itemList } = useOtherRequestedItems<ICustomItemSelectOptions[]>(
+		form.watch('without_item_request') ? '' : query
+	);
 	const fieldName = 'item_work_order_entry';
 	const selectedValues = form.watch('item_work_order_entry')?.map((item: any) => item.uuid) || [];
 	return (

--- a/src/pages/procurement/procure(store)/item-select-filter.tsx
+++ b/src/pages/procurement/procure(store)/item-select-filter.tsx
@@ -4,7 +4,8 @@ import { IFormSelectOption } from '@/components/core/form/types';
 import { FormField } from '@/components/ui/form';
 import CoreForm from '@core/form';
 
-import { useOtherRequestedItems } from '@/lib/common-queries/other';
+import { useOtherItem, useOtherRequestedItems } from '@/lib/common-queries/other';
+import nanoid from '@/lib/nanoid';
 
 import { ICustomItemSelectOptions } from './utils';
 
@@ -31,11 +32,16 @@ const ItemSelectFilter: React.FC<{ uuid?: string; form: any; index: number; disa
 }) => {
 	const pageAccess = useAccess('procurement__item') as string[];
 	const query = uuid ? `${getAccess(pageAccess)}` : `item_work_order_uuid=null&${getAccess(pageAccess)}`;
-	const { data: itemList } = useOtherRequestedItems<ICustomItemSelectOptions[]>(
-		form.watch('without_item_request') ? '' : query
-	);
+	const { data: itemList } = useOtherRequestedItems<ICustomItemSelectOptions[]>(query);
+	const { data: withOutReq } = useOtherItem<ICustomItemSelectOptions[]>(getAccess(pageAccess));
+
 	const fieldName = 'item_work_order_entry';
 	const selectedValues = form.watch('item_work_order_entry')?.map((item: any) => item.uuid) || [];
+	const selectedValuesWithOutReq = form.watch('item_work_order_entry')?.map((item: any) => item.item_uuid) || [];
+
+	const options = form.watch('without_item_request') ? withOutReq : itemList;
+	const optionsToExclude = form.watch('without_item_request') ? selectedValuesWithOutReq : selectedValues;
+
 	return (
 		<FormField
 			control={form.control}
@@ -43,15 +49,29 @@ const ItemSelectFilter: React.FC<{ uuid?: string; form: any; index: number; disa
 			render={(props) => (
 				<CoreForm.ReactSelect
 					disableLabel={true}
-					options={itemList!}
+					options={options!}
 					menuPortalTarget={document.body}
 					unique={true}
-					excludeOptions={selectedValues}
+					excludeOptions={optionsToExclude}
 					onChange={(e: ICustomItemSelectOptions) => {
-						form.setValue(`${fieldName}.${index}.uuid`, String(e?.value));
-						form.setValue(`${fieldName}.${index}.item_uuid`, String(e?.item_uuid));
-						form.setValue(`${fieldName}.${index}.request_quantity`, e?.request_quantity);
+						if (form.watch('without_item_request')) {
+							console.log('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+							form.setValue(`${fieldName}.${index}.item_uuid`, String(e?.value));
+							form.setValue(`${fieldName}.${index}.uuid`, '');
+						} else {
+							console.log('EEEEEEEEEEEEEEEEEEEEEEEEEEEEE');
+							form.setValue(`${fieldName}.${index}.uuid`, String(e?.value));
+							form.setValue(`${fieldName}.${index}.item_uuid`, String(e?.item_uuid));
+							form.setValue(`${fieldName}.${index}.request_quantity`, e?.request_quantity);
+						}
 					}}
+					value={options?.find((option) => {
+						if (form.watch('without_item_request')) {
+							return option.value === form.watch(`${fieldName}.${index}.item_uuid`);
+						} else {
+							return option.value === form.watch(`${fieldName}.${index}.uuid`);
+						}
+					})}
 					isDisabled={disabled}
 					placeholder='Select Item'
 					{...props}

--- a/src/pages/procurement/procure(store)/useGenerateItemWorkOrder.tsx
+++ b/src/pages/procurement/procure(store)/useGenerateItemWorkOrder.tsx
@@ -56,6 +56,7 @@ const useGenerateItemWorkOrder = ({ remove, watch, data, form }: IGenerateFieldD
 			header: 'Request Quantity',
 			accessorKey: 'request_quantity',
 			type: 'custom',
+			hidden: form.watch('without_item_request'),
 			component: (index: number) => {
 				return (
 					<RequestQuantity


### PR DESCRIPTION
Introduce a new option to handle requests without item entries, along with various bug fixes and improvements to the procurement store functionality. Adjustments include changes to pagination options and the item transfer action.