### PR TITLE
Refactor shift types by removing 'regular_and_evening'

### DIFF
--- a/src/pages/lib/config/schema/index.ts
+++ b/src/pages/lib/config/schema/index.ts
@@ -67,7 +67,7 @@ export const COURSE_SCHEMA = z.object({
 	financial_info_uuid: STRING_OPTIONAL,
 	code: STRING_REQUIRED,
 	credit: NUMBER_DOUBLE_REQUIRED,
-	shift_type: z.enum(['regular', 'evening', 'regular_and_evening']),
+	shift_type: z.enum(['regular', 'evening']),
 	course_type: z.enum(['general', 'lab']),
 	remarks: STRING_NULLABLE,
 	regular_section: z.array(
@@ -95,7 +95,8 @@ export const COURSE_NULL: Partial<ICourse> = {
 	credit: 0,
 	financial_info_uuid: '',
 	remarks: '',
-	shift_type: 'regular_and_evening',
+	course_type: 'general',
+	shift_type: 'regular',
 	regular_section: [],
 	evening_section: [],
 };

--- a/src/pages/lib/course/entry.tsx
+++ b/src/pages/lib/course/entry.tsx
@@ -298,7 +298,7 @@ const Entry = () => {
 				/>
 			</CoreForm.Section>
 
-			{(form.watch('shift_type') === 'regular' || form.watch('shift_type') === 'regular_and_evening') && (
+			{form.watch('shift_type') === 'regular' && (
 				<CoreForm.DynamicFields
 					title='Regular'
 					form={form}
@@ -308,7 +308,7 @@ const Entry = () => {
 					handleAdd={handleAdd}
 				/>
 			)}
-			{(form.watch('shift_type') === 'evening' || form.watch('shift_type') === 'regular_and_evening') && (
+			{form.watch('shift_type') === 'evening' && (
 				<CoreForm.DynamicFields
 					title='Evening'
 					form={form}

--- a/src/pages/lib/course/utils.ts
+++ b/src/pages/lib/course/utils.ts
@@ -34,10 +34,6 @@ export const shiftTypeOptions = [
 		label: 'Regular',
 		value: 'regular',
 	},
-	{
-		label: 'Regular & Evening',
-		value: 'regular_and_evening',
-	},
 ];
 
 export const courseTypeOptions = [

--- a/src/pages/lib/room-details/_components/pdf-selector.tsx
+++ b/src/pages/lib/room-details/_components/pdf-selector.tsx
@@ -19,7 +19,7 @@ interface PDFSelectorProps {
 	loading?: boolean;
 }
 
-export function PDFSelector({ data, onPdf, onPdfV2, onTeacherWisePdf, loading = false }: PDFSelectorProps) {
+export function PDFSelector({ data, onPdf, onPdfV2, loading = false }: PDFSelectorProps) {
 	const [selectedOption, setSelectedOption] = useState<string>('PDF');
 
 	const handleOptionSelect = (option: string, action: () => void) => {
@@ -30,13 +30,13 @@ export function PDFSelector({ data, onPdf, onPdfV2, onTeacherWisePdf, loading = 
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
-				<Button variant='outline' size='sm' className='h-9 px-3' disabled={loading}>
+				<Button variant='outline' size='sm' className='h-9 w-fit px-6' disabled={loading}>
 					<Book className='mr-2 h-4 w-4' />
 					{selectedOption}
 					<ChevronDown className='ml-1 h-3 w-3' />
 				</Button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align='end' className='w-48'>
+			<DropdownMenuContent align='end' className='dropdown-content-width-same-as-trigger'>
 				<DropdownMenuItem
 					onClick={() => handleOptionSelect('PDF', () => onPdf(data))}
 					className='cursor-pointer'

--- a/src/pages/lib/room-details/index.tsx
+++ b/src/pages/lib/room-details/index.tsx
@@ -247,12 +247,14 @@ export default function RoomDetails() {
 						</div> */}
 						<div className='flex flex-col'>
 							<label className='text-sm font-medium text-slate-700'>Select Room</label>
-							<RoomSelector
-								rooms={rooms}
-								selectedRoom={selectedRoom}
-								onRoomSelect={selectRoom}
-								loading={loading}
-							/>
+							<div className='min-w-80'>
+								<RoomSelector
+									rooms={rooms}
+									selectedRoom={selectedRoom}
+									onRoomSelect={selectRoom}
+									loading={loading}
+								/>
+							</div>
 						</div>
 
 						{canShowSchedule && (

--- a/src/pages/procurement/item/config/columns/index.tsx
+++ b/src/pages/procurement/item/config/columns/index.tsx
@@ -65,16 +65,16 @@ export const itemColumns = (
 		header: 'Threshold',
 		enableColumnFilter: true,
 	},
-	// {
-	// 	id: 'request_action_trx',
-	// 	header: 'Request \nItem',
-	// 	cell: (info) => <Transfer onClick={() => handleRequest(info.row)} />,
-	// 	size: 40,
-	// 	meta: {
-	// 		hidden: !actionTrxAccess,
-	// 		disableFullFilter: true,
-	// 	},
-	// },
+	{
+		id: 'request_action_trx',
+		header: 'Request \nItem',
+		cell: (info) => <Transfer onClick={() => handleRequest(info.row)} />,
+		size: 40,
+		meta: {
+			hidden: !actionTrxAccess,
+			disableFullFilter: true,
+		},
+	},
 
 	{
 		accessorKey: 'unit',

--- a/src/routes/private/procurement.tsx
+++ b/src/routes/private/procurement.tsx
@@ -260,13 +260,13 @@ const procurementRoutes: IRoute[] = [
 				page_name: 'procurement__item_update',
 				actions: ['create', 'read', 'update', 'delete'],
 			},
-			// {
-			// 	name: 'Item Request',
-			// 	path: '/procurement/item-request',
-			// 	element: <ItemRequest />,
-			// 	page_name: 'procurement__item_request',
-			// 	actions: ['create', 'read', 'update', 'delete'],
-			// },
+			{
+				name: 'Item Request',
+				path: '/procurement/item-request',
+				element: <ItemRequest />,
+				page_name: 'procurement__item_request',
+				actions: ['create', 'read', 'update', 'delete'],
+			},
 			{
 				name: 'Requisition',
 				path: '/procurement/requisition',


### PR DESCRIPTION
Eliminate the 'regular_and_evening' shift type from the schema and related components to simplify the shift type options. Update the affected areas to ensure consistent behavior with the remaining shift types.